### PR TITLE
chore: use int32 instead of int

### DIFF
--- a/api/v1alpha1/gatewaylbconfiguration_types.go
+++ b/api/v1alpha1/gatewaylbconfiguration_types.go
@@ -54,7 +54,7 @@ type GatewayLBConfigurationStatus struct {
 	FrontendIP string `json:"frontendIP,omitempty"`
 
 	// Listening port of the gateway side wireguard daemon.
-	ServerPort int `json:"serverPort,omitempty"`
+	ServerPort int32 `json:"serverPort,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/staticgatewayconfiguration_types.go
+++ b/api/v1alpha1/staticgatewayconfiguration_types.go
@@ -72,7 +72,7 @@ type GatewayWireguardProfile struct {
 	WireguardServerIP string `json:"wireguardServerIP,omitempty"`
 
 	// Listening port of the gateway side wireguard daemon.
-	WireguardServerPort int `json:"wireguardServerPort,omitempty"`
+	WireguardServerPort int32 `json:"wireguardServerPort,omitempty"`
 
 	// Gateway side wireguard public key.
 	WireguardPublicKey string `json:"wireguardPublicKey,omitempty"`

--- a/config/crd/bases/kube-egress-gateway.microsoft.com_gatewaylbconfigurations.yaml
+++ b/config/crd/bases/kube-egress-gateway.microsoft.com_gatewaylbconfigurations.yaml
@@ -63,6 +63,7 @@ spec:
                 type: string
               serverPort:
                 description: Listening port of the gateway side wireguard daemon.
+                format: int32
                 type: integer
             type: object
         type: object

--- a/config/crd/bases/kube-egress-gateway.microsoft.com_staticgatewayconfigurations.yaml
+++ b/config/crd/bases/kube-egress-gateway.microsoft.com_staticgatewayconfigurations.yaml
@@ -122,6 +122,7 @@ spec:
                     type: string
                   wireguardServerPort:
                     description: Listening port of the gateway side wireguard daemon.
+                    format: int32
                     type: integer
                 type: object
               message:

--- a/controllers/const.go
+++ b/controllers/const.go
@@ -14,13 +14,13 @@ const (
 	WireguardSecretKeyName = "WireguardPrivateKey"
 
 	// Wireguard listening port range start, inclusive
-	WireguardPortStart = 6000
+	WireguardPortStart int32 = 6000
 
 	// Wireguard listening port range end, exclusive
-	WireguardPortEnd = 7000
+	WireguardPortEnd int32 = 7000
 
 	// Wireguard daemon on gateway nodes listening port
-	WireguardDaemonServicePort = 8080
+	WireguardDaemonServicePort int32 = 8080
 
 	// nodepool name tag key in aks clusters
 	AKSNodepoolTagKey = "aks-managed-poolName"

--- a/controllers/gatewaylbconfiguration_controller.go
+++ b/controllers/gatewaylbconfiguration_controller.go
@@ -128,7 +128,7 @@ func (r *GatewayLBConfigurationReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 	lbConfig.Status.FrontendIP = ip
-	lbConfig.Status.ServerPort = int(port)
+	lbConfig.Status.ServerPort = port
 
 	if !equality.Semantic.DeepEqual(existing, lbConfig) {
 		log.Info(fmt.Sprintf("Updating GatewayLBConfiguration %s/%s", lbConfig.Namespace, lbConfig.Name))
@@ -409,7 +409,7 @@ func getExpectedLBProbe(
 	probeProp := &network.ProbePropertiesFormat{
 		RequestPath: to.Ptr("/" + lbConfig.Namespace + "/" + lbConfig.Name),
 		Protocol:    to.Ptr(network.ProbeProtocolHTTP),
-		Port:        to.Ptr(int32(WireguardDaemonServicePort)),
+		Port:        to.Ptr(WireguardDaemonServicePort),
 	}
 	return &network.Probe{
 		Name:       probeName,
@@ -472,7 +472,7 @@ func selectPortForLBRule(targetRule *network.LoadBalancingRule, lbRules []*netwo
 	}
 	for i, portInUse := range ports {
 		if !portInUse {
-			return int32(i + WireguardPortStart), nil
+			return int32(i) + WireguardPortStart, nil
 		}
 	}
 	return 0, fmt.Errorf("selectPortForLBRule: No available ports")

--- a/controllers/gatewaylbconfiguration_controller_test.go
+++ b/controllers/gatewaylbconfiguration_controller_test.go
@@ -326,7 +326,7 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 					getErr = getResource(cl, foundLBConfig)
 					Expect(getErr).To(BeNil())
 					Expect(foundLBConfig.Status.FrontendIP).To(Equal("10.0.0.4"))
-					Expect(foundLBConfig.Status.ServerPort).To(Equal(6000))
+					Expect(foundLBConfig.Status.ServerPort).To(Equal(int32(6000)))
 				})
 
 				It("should not update LB when lb rule and probe are expected", func() {
@@ -337,7 +337,7 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 					Expect(reconcileErr).To(BeNil())
 					Expect(res).To(Equal(ctrl.Result{}))
 					Expect(foundLBConfig.Status.FrontendIP).To(Equal("10.0.0.4"))
-					Expect(foundLBConfig.Status.ServerPort).To(Equal(6000))
+					Expect(foundLBConfig.Status.ServerPort).To(Equal(int32(6000)))
 				})
 
 				It("should drop incorrect lbRule and create new one", func() {
@@ -356,7 +356,7 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 					getErr = getResource(cl, foundLBConfig)
 					Expect(getErr).To(BeNil())
 					Expect(foundLBConfig.Status.FrontendIP).To(Equal("10.0.0.4"))
-					Expect(foundLBConfig.Status.ServerPort).To(Equal(6000))
+					Expect(foundLBConfig.Status.ServerPort).To(Equal(int32(6000)))
 				})
 
 				It("should drop incorrect lbProbe and create new one", func() {
@@ -365,17 +365,17 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 						{
 							RequestPath: to.Ptr("/" + testNamespace + "/" + testName + "1"),
 							Protocol:    to.Ptr(network.ProbeProtocolHTTP),
-							Port:        to.Ptr(int32(WireguardDaemonServicePort)),
+							Port:        to.Ptr(WireguardDaemonServicePort),
 						},
 						{
 							RequestPath: to.Ptr("/" + testNamespace + "/" + testName),
 							Protocol:    to.Ptr(network.ProbeProtocolTCP),
-							Port:        to.Ptr(int32(WireguardDaemonServicePort)),
+							Port:        to.Ptr(WireguardDaemonServicePort),
 						},
 						{
 							RequestPath: to.Ptr("/" + testNamespace + "/" + testName),
 							Protocol:    to.Ptr(network.ProbeProtocolHTTP),
-							Port:        to.Ptr(int32(WireguardDaemonServicePort) + 1),
+							Port:        to.Ptr(WireguardDaemonServicePort + 1),
 						},
 					} {
 						existingLB.Properties.Probes[0].Properties = prop
@@ -392,7 +392,7 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 						getErr = getResource(cl, foundLBConfig)
 						Expect(getErr).To(BeNil())
 						Expect(foundLBConfig.Status.FrontendIP).To(Equal("10.0.0.4"))
-						Expect(foundLBConfig.Status.ServerPort).To(Equal(6000))
+						Expect(foundLBConfig.Status.ServerPort).To(Equal(int32(6000)))
 					}
 				})
 
@@ -418,7 +418,7 @@ var _ = Describe("GatewayLBConfiguration controller unit tests", func() {
 					getErr = getResource(cl, foundLBConfig)
 					Expect(getErr).To(BeNil())
 					Expect(foundLBConfig.Status.FrontendIP).To(Equal("10.0.0.4"))
-					Expect(foundLBConfig.Status.ServerPort).To(Equal(6001))
+					Expect(foundLBConfig.Status.ServerPort).To(Equal(int32(6001)))
 				})
 			})
 		})
@@ -695,7 +695,7 @@ func getExpectedLB() *network.LoadBalancer {
 					Properties: &network.ProbePropertiesFormat{
 						RequestPath: to.Ptr("/" + testNamespace + "/" + testName),
 						Protocol:    to.Ptr(network.ProbeProtocolHTTP),
-						Port:        to.Ptr(int32(WireguardDaemonServicePort)),
+						Port:        to.Ptr(WireguardDaemonServicePort),
 					},
 				},
 			},

--- a/controllers/staticgatewayconfiguration_controller_test.go
+++ b/controllers/staticgatewayconfiguration_controller_test.go
@@ -239,7 +239,7 @@ var _ = Describe("StaticGatewayConfiguration controller unit tests", func() {
 			It("should update gwConfig's status from secret, lbConfig and vmConfig", func() {
 				Expect(foundGWConfig.Status.WireguardPublicKey).To(Equal(pubK))
 				Expect(foundGWConfig.Status.WireguardServerIP).To(Equal("1.1.1.1"))
-				Expect(foundGWConfig.Status.WireguardServerPort).To(Equal(6000))
+				Expect(foundGWConfig.Status.WireguardServerPort).To(Equal(int32(6000)))
 				Expect(foundGWConfig.Status.PublicIpPrefix).To(Equal("1.2.3.4/31"))
 			})
 		})


### PR DESCRIPTION
use int32 instead of int following k8s api conventions.