### PR TITLE
add action for generating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,197 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-kube-egress-gateway-controller:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          # TODO: multi-arch not supported yet
+          # - os: linux
+          #   arch: arm
+          # - os: linux
+          #   arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build binary
+        run: |
+          rm -rf ./bin
+          ARCH=${{ matrix.arch }} make bin/kube-egress-gateway-controller
+          mv bin/manager bin/kube-egress-gateway-controller-manager-${{ matrix.os }}-${{ matrix.arch }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: kube-egress-gateway-controller-manager-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/kube-egress-gateway-controller-manager-${{ matrix.os }}-${{ matrix.arch }}
+          if-no-files-found: error
+
+  build-kube-egress-gateway-daemon:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          # TODO: multi-arch not supported yet
+          # - os: linux
+          #   arch: arm
+          # - os: linux
+          #   arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build binary
+        run: |
+          rm -rf ./bin
+          ARCH=${{ matrix.arch }} make bin/kube-egress-gateway-daemon
+          mv bin/daemon bin/kube-egress-gateway-daemon-manager-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kube-egress-gateway-daemon-manager-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/kube-egress-gateway-daemon-manager-${{ matrix.os }}-${{ matrix.arch }}
+
+  build-kube-egress-cni:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          # TODO: multi-arch not supported yet
+          # - os: linux
+          #   arch: arm
+          # - os: linux
+          #   arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build binary
+        run: |
+          rm -rf ./bin
+          ARCH=${{ matrix.arch }} make bin/kube-egress-cni
+          mv bin/cni bin/kube-egress-cni-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kube-egress-cni-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/kube-egress-cni-${{ matrix.os }}-${{ matrix.arch }}
+
+  build-kube-egress-cni-ipam:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          # TODO: multi-arch not supported yet
+          # - os: linux
+          #   arch: arm
+          # - os: linux
+          #   arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build binary
+        run: |
+          rm -rf ./bin
+          ARCH=${{ matrix.arch }} make bin/kube-egress-cni-ipam
+          mv bin/cni-ipam bin/kube-egress-cni-ipam-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kube-egress-cni-ipam-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/kube-egress-cni-ipam-${{ matrix.os }}-${{ matrix.arch }}
+
+  build-kube-egress-gateway-cnimanager:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          # TODO: multi-arch not supported yet
+          # - os: linux
+          #   arch: arm
+          # - os: linux
+          #   arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Build binary
+        run: |
+          rm -rf ./bin
+          ARCH=${{ matrix.arch }} make bin/kube-egress-gateway-cnimanager
+          mv bin/cnimanager bin/kube-egress-gateway-cnimanager-${{ matrix.os }}-${{ matrix.arch }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: kube-egress-gateway-cnimanager-${{ matrix.os }}-${{ matrix.arch }}
+          path: bin/kube-egress-gateway-cnimanager-${{ matrix.os }}-${{ matrix.arch }}
+  
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build-kube-egress-gateway-controller
+      - build-kube-egress-gateway-daemon
+      - build-kube-egress-cni
+      - build-kube-egress-cni-ipam
+      - build-kube-egress-gateway-cnimanager
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            ./artifacts/kube-egress-gateway-controller-manager-*-*/*
+            ./artifacts/kube-egress-gateway-daemon-manager-*-*/*
+            ./artifacts/kube-egress-cni-*-*/*
+            ./artifacts/kube-egress-cni-ipam-*-*/*
+            ./artifacts/kube-egress-gateway-cnimanager-*-*/*

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,21 @@ IMAGE_REGISTRY ?= local
 IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate fmt vet bin/kube-egress-gateway-controller bin/kube-egress-gateway-daemon bin/kube-egress-cni bin/kube-egress-cni-ipam bin/kube-egress-gateway-cnimanager ## Build manager binary.
+
+bin/kube-egress-gateway-controller:
 	CGO_ENABLED=0 go build -o bin/manager ./cmd/kube-egress-gateway-controller/main.go
+
+bin/kube-egress-gateway-daemon:
 	CGO_ENABLED=0 go build -o bin/daemon ./cmd/kube-egress-gateway-daemon/main.go
+
+bin/kube-egress-cni:
 	CGO_ENABLED=0 go build -o bin/cni ./cmd/kube-egress-cni/main.go
+
+bin/kube-egress-cni-ipam:
 	CGO_ENABLED=0 go build -o bin/cni-ipam ./cmd/kube-egress-cni-ipam/main.go
+
+bin/kube-egress-gateway-cnimanager:
 	CGO_ENABLED=0 go build -o bin/cnimanager ./cmd/kube-egress-gateway-cnimanager/main.go
 
 AZURE_CONFIG_FILE ?= ./tests/deploy/azure.json


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot</samp>

This pull request adds a GitHub workflow for releasing the kube-egress-gateway project and updates the Makefile to support cross-compiling binaries for different platforms. The workflow is triggered by tags or manually and creates a draft release with artifacts and release notes. The Makefile uses separate targets for each binary and sets the GOARCH flag based on the `ARCH` environment variable.
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot</samp>

* Add a GitHub workflow for releasing the project ([link](https://github.com/Azure/kube-egress-gateway/pull/162/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L1-R196))
* Modify the Makefile to use separate targets for each binary ([link](https://github.com/Azure/kube-egress-gateway/pull/162/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L83-R97))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot</samp>

> _`kube-egress-gateway`_
> _New workflow for release_
> _Autumn harvest time_