### PR TITLE
add configurations for pod ingress traffic

### DIFF
--- a/pkg/cni/routes/routes.go
+++ b/pkg/cni/routes/routes.go
@@ -24,25 +24,48 @@ SOFTWARE
 package routes
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"strconv"
 
+	"github.com/Azure/kube-egress-gateway/pkg/consts"
+	"github.com/Azure/kube-egress-gateway/pkg/iptableswrapper"
+	"github.com/Azure/kube-egress-gateway/pkg/netlinkwrapper"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 )
+
+type Interface interface {
+	SetPodRoutes(ifName string, exceptionCidrs []string) error
+}
+
+type runner struct {
+	netlink  netlinkwrapper.Interface
+	iptables iptableswrapper.Interface
+}
+
+var routesRunner runner
+
+func init() {
+	routesRunner = runner{
+		netlink:  netlinkwrapper.NewNetLink(),
+		iptables: iptableswrapper.NewIPTables(),
+	}
+}
 
 func SetPodRoutes(ifName string, exceptionCidrs []string) error {
 	// 1. removes existing routes
 	// 2. add original default route gateway to eth0
 	// 3. routes exceptional cidrs (traffic avoiding gateway) to base interface (eth0)
 	// 4. add default route to wireguard interface
-	eth0Link, err := netlink.LinkByName("eth0")
+	eth0Link, err := routesRunner.netlink.LinkByName("eth0")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve eth0 interface: %w", err)
 	}
 
-	routes, err := netlink.RouteList(eth0Link, nl.FAMILY_ALL)
+	routes, err := routesRunner.netlink.RouteList(eth0Link, nl.FAMILY_ALL)
 	if err != nil {
 		return fmt.Errorf("failed to list all routes on eth0: %w", err)
 	}
@@ -53,12 +76,16 @@ func SetPodRoutes(ifName string, exceptionCidrs []string) error {
 		if route.Dst == nil && route.Family == nl.FAMILY_V4 {
 			defaultRoute = &route
 		}
-		if err := netlink.RouteDel(&route); err != nil {
+		if err := routesRunner.netlink.RouteDel(&route); err != nil {
 			return fmt.Errorf("failed to delete route (%s): %w", route, err)
 		}
 	}
 
-	err = netlink.RouteReplace(&netlink.Route{
+	if defaultRoute == nil {
+		return errors.New("failed to find default route")
+	}
+
+	err = routesRunner.netlink.RouteReplace(&netlink.Route{
 		Dst:       &net.IPNet{IP: defaultRoute.Gw, Mask: net.CIDRMask(32, 32)},
 		LinkIndex: eth0Link.Attrs().Index,
 		Scope:     netlink.SCOPE_LINK,
@@ -78,13 +105,13 @@ func SetPodRoutes(ifName string, exceptionCidrs []string) error {
 			LinkIndex: eth0Link.Attrs().Index,
 			Protocol:  unix.RTPROT_STATIC,
 		}
-		err = netlink.RouteReplace(&gatewayRoute)
+		err = routesRunner.netlink.RouteReplace(&gatewayRoute)
 		if err != nil {
 			return fmt.Errorf("failed to add route (%s): %w", gatewayRoute, err)
 		}
 	}
 
-	wgLink, err := netlink.LinkByName(ifName)
+	wgLink, err := routesRunner.netlink.LinkByName(ifName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve wireguard interface: %w", err)
 	}
@@ -102,9 +129,51 @@ func SetPodRoutes(ifName string, exceptionCidrs []string) error {
 		Family:    nl.FAMILY_V4,
 	}
 
-	err = netlink.RouteReplace(&wg_default_route)
+	err = routesRunner.netlink.RouteReplace(&wg_default_route)
 	if err != nil {
 		return fmt.Errorf("failed to add default wireguard route (%s): %w", wg_default_route, err)
+	}
+
+	err = addRoutingForIngress(eth0Link, *defaultRoute)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addRoutingForIngress(eth0Link netlink.Link, defaultRoute netlink.Route) error {
+	// add iptables rule to mark traffic from eth0
+	ipt, err := routesRunner.iptables.New()
+	if err != nil {
+		return fmt.Errorf("failed to create iptable: %w", err)
+	}
+	err = ipt.AppendUnique(consts.MangleTable, consts.PreRoutingChain, "-i", "eth0", "-j", "MARK", "--set-mark", strconv.Itoa(consts.Eth0Mark))
+	if err != nil {
+		return fmt.Errorf("failed to append iptables set-mark rule: %w", err)
+	}
+	err = ipt.AppendUnique(consts.MangleTable, consts.PreRoutingChain, "-j", "CONNMARK", "--save-mark")
+	if err != nil {
+		return fmt.Errorf("failed to append iptables save-mark rule: %w", err)
+	}
+	err = ipt.AppendUnique(consts.MangleTable, consts.OutputChain, "-m", "connmark", "--mark", strconv.Itoa(consts.Eth0Mark), "-j", "CONNMARK", "--restore-mark")
+	if err != nil {
+		return fmt.Errorf("failed to append iptables restore-mark rule: %w", err)
+	}
+
+	// add ip rule: lookup separate routing table if packet is marked
+	rule := netlink.NewRule()
+	rule.Mark = consts.Eth0Mark
+	rule.Table = consts.Eth0Mark
+	err = routesRunner.netlink.RuleAdd(rule)
+	if err != nil {
+		return fmt.Errorf("failed to add routing rule: %w", err)
+	}
+
+	// add route
+	defaultRoute.Table = consts.Eth0Mark
+	err = routesRunner.netlink.RouteReplace(&defaultRoute)
+	if err != nil {
+		return fmt.Errorf("failed to add default route via eth0: %w", err)
 	}
 	return nil
 }

--- a/pkg/cni/routes/routes_test.go
+++ b/pkg/cni/routes/routes_test.go
@@ -1,0 +1,131 @@
+/*
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+*/
+package routes
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+
+	"github.com/Azure/kube-egress-gateway/pkg/iptableswrapper/mockiptableswrapper"
+	"github.com/Azure/kube-egress-gateway/pkg/netlinkwrapper/mocknetlinkwrapper"
+	"github.com/golang/mock/gomock"
+	"github.com/vishvananda/netlink"
+)
+
+func TestSetPodRoutes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mnl := mocknetlinkwrapper.NewMockInterface(ctrl)
+	mipt := mockiptableswrapper.NewMockInterface(ctrl)
+	mtable := mockiptableswrapper.NewMockIpTables(ctrl)
+	routesRunner = runner{
+		netlink:  mnl,
+		iptables: mipt,
+	}
+
+	eth0 := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "eth0", Index: 1}}
+	wg0 := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "wg0", Index: 2}}
+	defaultGw := net.IPv4(10, 244, 0, 1)
+	existingRoutes := []netlink.Route{
+		// default route
+		{
+			Family:    nl.FAMILY_V4,
+			Gw:        defaultGw,
+			LinkIndex: 1,
+		},
+		{
+			Dst:       &net.IPNet{IP: net.IPv4(10, 244, 0, 0), Mask: net.CIDRMask(24, 32)},
+			LinkIndex: 1,
+		},
+	}
+	_, net1, _ := net.ParseCIDR("1.2.3.4/32")
+	_, net2, _ := net.ParseCIDR("172.17.0.4/16")
+	_, dnet, _ := net.ParseCIDR("0.0.0.0/0")
+	rule := netlink.NewRule()
+	rule.Mark = 8738
+	rule.Table = 8738
+	defaultRoute := netlink.Route{
+		Family:    nl.FAMILY_V4,
+		Gw:        defaultGw,
+		LinkIndex: 1,
+		Table:     8738,
+	}
+	gomock.InOrder(
+		// retrieve eth0 link
+		mnl.EXPECT().LinkByName("eth0").Return(eth0, nil),
+		// get existing routes
+		mnl.EXPECT().RouteList(eth0, netlink.FAMILY_ALL).Return(existingRoutes, nil),
+		// delete existing routes
+		mnl.EXPECT().RouteDel(&existingRoutes[0]).Return(nil),
+		mnl.EXPECT().RouteDel(&existingRoutes[1]).Return(nil),
+		// add route to default gateway via eth0
+		mnl.EXPECT().RouteReplace(&netlink.Route{
+			Dst:       &net.IPNet{IP: defaultGw, Mask: net.CIDRMask(32, 32)},
+			LinkIndex: 1,
+			Scope:     netlink.SCOPE_LINK,
+		}).Return(nil),
+		// add routes to exceptional CIDRs via eth0
+		mnl.EXPECT().RouteReplace(&netlink.Route{
+			Dst:       net1,
+			Gw:        defaultGw,
+			LinkIndex: 1,
+			Protocol:  unix.RTPROT_STATIC,
+		}).Return(nil),
+		mnl.EXPECT().RouteReplace(&netlink.Route{
+			Dst:       net2,
+			Gw:        defaultGw,
+			LinkIndex: 1,
+			Protocol:  unix.RTPROT_STATIC,
+		}).Return(nil),
+		// retrieve wg0 link
+		mnl.EXPECT().LinkByName("wg0").Return(wg0, nil),
+		// add default route via wg0
+		mnl.EXPECT().RouteReplace(&netlink.Route{
+			Dst: dnet,
+			Gw:  nil,
+			Via: &netlink.Via{
+				Addr:       net.ParseIP("fe80::1"),
+				AddrFamily: nl.FAMILY_V6,
+			},
+			LinkIndex: 2,
+			Scope:     netlink.SCOPE_UNIVERSE,
+			Family:    nl.FAMILY_V4,
+		}),
+		// add iptables rules
+		mipt.EXPECT().New().Return(mtable, nil),
+		mtable.EXPECT().AppendUnique("mangle", "PREROUTING", "-i", "eth0", "-j", "MARK", "--set-mark", "8738").Return(nil),
+		mtable.EXPECT().AppendUnique("mangle", "PREROUTING", "-j", "CONNMARK", "--save-mark").Return(nil),
+		mtable.EXPECT().AppendUnique("mangle", "OUTPUT", "-m", "connmark", "--mark", "8738", "-j", "CONNMARK", "--restore-mark").Return(nil),
+		mnl.EXPECT().RuleAdd(rule).Return(nil),
+		// add route in 8738 table
+		mnl.EXPECT().RouteReplace(&defaultRoute).Return(nil),
+	)
+	err := SetPodRoutes("wg0", []string{"1.2.3.4/32", "172.17.0.4/16"})
+	if err != nil {
+		t.Fatalf("SetPodRoutes returns unexpected error: %v", err)
+	}
+}

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -68,8 +68,17 @@ const (
 	// post routing chain name
 	PostRoutingChain = "POSTROUTING"
 
+	// pre routing chain name
+	PreRoutingChain = "PREROUTING"
+
+	// output chain name
+	OutputChain = "OUTPUT"
+
 	// nat table name
 	NatTable = "nat"
+
+	// mangle table name
+	MangleTable = "mangle"
 
 	// environment variable name for pod namespace
 	PodNamespaceEnvKey = "MY_POD_NAMESPACE"
@@ -79,6 +88,9 @@ const (
 
 	// iptables rule comment
 	IPTablesRuleComment = "no SNAT for traffic from netns "
+
+	// mark for traffic from eth0 in pod namespace - 0x2222
+	Eth0Mark int = 8738
 )
 
 const (

--- a/pkg/iptableswrapper/iptables.go
+++ b/pkg/iptableswrapper/iptables.go
@@ -26,9 +26,11 @@ package iptableswrapper
 import "github.com/coreos/go-iptables/iptables"
 
 type IpTables interface {
+	// ApendUnique appends given rulespec if not exists
+	AppendUnique(table, chain string, rulespec ...string) error
 	// Exists checks if given rulespec in specified table/chain exists
 	Exists(table, chain string, rulespec ...string) (bool, error)
-	//Insert inserts given rulespec to specified table/chain at specified position
+	// Insert inserts given rulespec to specified table/chain at specified position
 	Insert(table, chain string, pos int, rulespec ...string) error
 	// Delete removes rulespec in specified table/chain
 	Delete(table, chain string, rulespec ...string) error

--- a/pkg/iptableswrapper/mockiptableswrapper/interface.go
+++ b/pkg/iptableswrapper/mockiptableswrapper/interface.go
@@ -34,6 +34,25 @@ func (m *MockIpTables) EXPECT() *MockIpTablesMockRecorder {
 	return m.recorder
 }
 
+// AppendUnique mocks base method.
+func (m *MockIpTables) AppendUnique(table, chain string, rulespec ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{table, chain}
+	for _, a := range rulespec {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AppendUnique", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendUnique indicates an expected call of AppendUnique.
+func (mr *MockIpTablesMockRecorder) AppendUnique(table, chain interface{}, rulespec ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{table, chain}, rulespec...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUnique", reflect.TypeOf((*MockIpTables)(nil).AppendUnique), varargs...)
+}
+
 // Delete mocks base method.
 func (m *MockIpTables) Delete(table, chain string, rulespec ...string) error {
 	m.ctrl.T.Helper()

--- a/pkg/netlinkwrapper/mocknetlinkwrapper/interface.go
+++ b/pkg/netlinkwrapper/mocknetlinkwrapper/interface.go
@@ -204,3 +204,17 @@ func (mr *MockInterfaceMockRecorder) RouteReplace(route interface{}) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteReplace", reflect.TypeOf((*MockInterface)(nil).RouteReplace), route)
 }
+
+// RuleAdd mocks base method.
+func (m *MockInterface) RuleAdd(rule *netlink.Rule) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RuleAdd", rule)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RuleAdd indicates an expected call of RuleAdd.
+func (mr *MockInterfaceMockRecorder) RuleAdd(rule interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RuleAdd", reflect.TypeOf((*MockInterface)(nil).RuleAdd), rule)
+}

--- a/pkg/netlinkwrapper/netlink.go
+++ b/pkg/netlinkwrapper/netlink.go
@@ -50,6 +50,8 @@ type Interface interface {
 	RouteDel(route *netlink.Route) error
 	// RouteList gets a list of routes in the system
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
+	// RuleAdd adds a rule
+	RuleAdd(rule *netlink.Rule) error
 }
 
 type nl struct{}
@@ -104,4 +106,8 @@ func (*nl) RouteDel(route *netlink.Route) error {
 
 func (*nl) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
 	return netlink.RouteList(link, family)
+}
+
+func (*nl) RuleAdd(rule *netlink.Rule) error {
+	return netlink.RuleAdd(rule)
 }


### PR DESCRIPTION
Add iptables rule, ip rule, and routes to allow response packets from ingress requests to flow back from eth0.