### PR TITLE
Add a cniConfMgr in cniManager to create kube-egress-cni configuration and monitor /etc/cni/net.d changes.

### DIFF
--- a/config/cnimanager/daemon/cnimanager.yaml
+++ b/config/cnimanager/daemon/cnimanager.yaml
@@ -36,11 +36,15 @@ spec:
             - /kube-egress-gateway-cnimanager
           args:
             - serve
+            # - --exception-cidrs=
+            - --cni-conf-file=01-egressgateway.conflist
           image: cnimanager:latest
           name: cnimanager
           securityContext:
             privileged: true
           volumeMounts:
+            - mountPath: /etc/cni/net.d
+              name: cni-conf
             - mountPath: /proc
               name: hostpath-proc
               mountPropagation: Bidirectional
@@ -76,6 +80,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64
+      hostNetwork: true
       serviceAccountName: cni-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -91,3 +96,6 @@ spec:
         - name: cni-bin
           hostPath:
             path: /opt/cni/bin/
+        - name: cni-conf
+          hostPath:
+            path: /etc/cni/net.d/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -49,12 +49,14 @@ target "cnimanager" {
     GRPC_HEALTH_PROBE_VERSION = "v0.4.14"
   }
 }
+
 target "cni-compile" {
   inherits = ["base"]
   args = {
     MAIN_ENTRY = "kube-egress-cni",
   }
 }
+
 target "cni" {
   inherits = ["cni-tags"]
   dockerfile = "cni.Dockerfile"
@@ -69,6 +71,7 @@ target "cni-ipam-compile" {
     MAIN_ENTRY = "kube-egress-cni-ipam",
   }
 }
+
 target "cni-ipam" {
   inherits = ["cni-ipam-tags"]
   dockerfile = "cni.Dockerfile"

--- a/pkg/cni/conf/confmanager.go
+++ b/pkg/cni/conf/confmanager.go
@@ -1,0 +1,283 @@
+/*
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+*/
+package conf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Azure/kube-egress-gateway/pkg/consts"
+	"github.com/Azure/kube-egress-gateway/pkg/logger"
+	"github.com/fsnotify/fsnotify"
+)
+
+type Manager struct {
+	cniConfDir     string
+	cniConfFile    string
+	cniConfWatcher *fsnotify.Watcher
+	exceptionCidrs []string
+}
+
+func NewCNIConfManager(cniConfDir, cniConfFile, exceptionCidrs string) (*Manager, error) {
+	cidrs, err := parseCidrs(exceptionCidrs)
+	if err != nil {
+		return nil, err
+	}
+
+	watcher, err := newWatcher(cniConfDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		cniConfDir:     cniConfDir,
+		cniConfFile:    cniConfFile,
+		cniConfWatcher: watcher,
+		exceptionCidrs: cidrs,
+	}, nil
+}
+
+func (mgr *Manager) Start(ctx context.Context) error {
+	log := logger.GetLogger()
+	defer func() {
+		log.Info("Stopping cni configuration directory monitoring")
+		if err := mgr.cniConfWatcher.Close(); err != nil {
+			log.Error(err, "failed to close watcher")
+		}
+	}()
+
+	log.Info("Installing cni configuration")
+	if err := mgr.insertCNIPluginConf(); err != nil {
+		return err
+	}
+
+	log.Info("Start to watch cni configuration changes", "conf directory", mgr.cniConfDir)
+	for {
+		select {
+		case event := <-mgr.cniConfWatcher.Events:
+			if strings.Contains(event.Name, mgr.cniConfFile) && !event.Has(fsnotify.Remove) {
+				// ignore our cni conf file change (unless it's deletion) to avoid loop
+				continue
+			}
+			log.Info("Detected changes in cni configuration directory, regenerating...", "change event", event)
+			if err := mgr.insertCNIPluginConf(); err != nil {
+				log.Error(err, "failed to regenerate cni conf")
+			}
+		case err := <-mgr.cniConfWatcher.Errors:
+			if err != nil {
+				log.Error(err, "failed to watch cni configuration directory changes")
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (mgr *Manager) insertCNIPluginConf() error {
+	file, err := findMasterPlugin(mgr.cniConfDir, mgr.cniConfFile)
+	if err != nil {
+		return err
+	}
+
+	ext := filepath.Ext(file)
+	var rawList map[string]interface{}
+	if ext == ".conflist" {
+		rawList, err = mgr.managePluginFromConfList(file)
+		if err != nil {
+			return err
+		}
+	} else {
+		rawList, err = mgr.managePluginFromConf(file)
+		if err != nil {
+			return err
+		}
+	}
+
+	newBytes, err := json.MarshalIndent(rawList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal bytes into json: %w, bytes: %s", err, string(newBytes))
+	}
+	tmpFile := filepath.Join(mgr.cniConfDir, mgr.cniConfFile+".tmp")
+	err = os.WriteFile(tmpFile, newBytes, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to tmp file: %w", err)
+	}
+	err = os.Rename(tmpFile, filepath.Join(mgr.cniConfDir, mgr.cniConfFile))
+	if err != nil {
+		return fmt.Errorf("failed to rename file: %w", err)
+	}
+	return nil
+}
+
+func newWatcher(cniConfDir string) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new watcher for %q: %v", cniConfDir, err)
+	}
+
+	if err = watcher.Add(cniConfDir); err != nil {
+		watcher.Close()
+		return nil, fmt.Errorf("failed to add watch on %q: %v", cniConfDir, err)
+	}
+
+	return watcher, nil
+}
+
+func (mgr *Manager) managePluginFromConf(file string) (map[string]interface{}, error) {
+	bytes, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cni config file %s: %w", file, err)
+	}
+	rawConf, rawList := make(map[string]interface{}), make(map[string]interface{})
+	if err = json.Unmarshal(bytes, &rawConf); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cni config: %w", err)
+	}
+
+	networkName, ok := rawConf["name"]
+	if !ok {
+		return nil, fmt.Errorf("failed to find network name in %s", file)
+	}
+	rawList["name"] = networkName
+	delete(rawConf, "name")
+
+	cniVersion, ok := rawConf["cniVersion"]
+	if ok {
+		cniVersion, ok = cniVersion.(string)
+		if !ok {
+			return nil, fmt.Errorf("cniVersion (%v) is not in string format", cniVersion)
+		}
+		rawList["cniVersion"] = cniVersion
+		delete(rawConf, "cniVersion")
+	}
+
+	var plugins []interface{}
+	plugins = append(plugins, rawConf)
+	plugins = append(plugins, map[string]interface{}{
+		"type":          consts.KubeEgressCNIName,
+		"ipam":          map[string]interface{}{"type": consts.KubeEgressIPAMCNIName},
+		"excludedCIDRs": mgr.exceptionCidrs,
+	})
+	rawList["plugins"] = plugins
+	return rawList, nil
+}
+
+func (mgr *Manager) managePluginFromConfList(file string) (map[string]interface{}, error) {
+	bytes, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cni config file %s: %w", file, err)
+	}
+	rawList := make(map[string]interface{})
+	if err = json.Unmarshal(bytes, &rawList); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal cni config: %w", err)
+	}
+	var plugins []interface{}
+	plug, ok := rawList["plugins"]
+	if !ok {
+		return nil, fmt.Errorf("failed to find plugins in cni config file %s", file)
+	}
+	plugins, ok = plug.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("plugins field is not an array in %s", file)
+	}
+	if len(plugins) == 0 {
+		return nil, fmt.Errorf("empty plugin list in cni config file %s", file)
+	}
+
+	// remove the plugin if it already exists
+	for i, plugin := range plugins {
+		p, ok := plugin.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed to parse plugin conf in file %s", file)
+		}
+		cniType, ok := p["type"]
+		if !ok {
+			return nil, fmt.Errorf("failed to find type in plugin conf in file %s", file)
+		}
+		cniTypeStr, ok := cniType.(string)
+		if ok && strings.EqualFold(cniTypeStr, consts.KubeEgressCNIName) {
+			plugins = append(plugins[:i], plugins[i+1:]...)
+			break
+		}
+	}
+
+	// insert kube-egress-gateway-cni at plugins[1]
+	plugins = append(plugins[:1], append([]interface{}{map[string]interface{}{
+		"type":          consts.KubeEgressCNIName,
+		"ipam":          map[string]interface{}{"type": consts.KubeEgressIPAMCNIName},
+		"excludedCIDRs": mgr.exceptionCidrs,
+	}}, plugins[1:]...)...)
+
+	rawList["plugins"] = plugins
+	return rawList, nil
+}
+
+func findMasterPlugin(cniConfDir, cniConfFile string) (string, error) {
+	var confFiles []string
+	files, err := os.ReadDir(cniConfDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read cni config directory: %w", err)
+	}
+
+	for _, file := range files {
+		if !file.Type().IsRegular() {
+			continue
+		}
+		if strings.EqualFold(file.Name(), cniConfFile) {
+			continue
+		}
+		fileExtension := filepath.Ext(file.Name())
+		if fileExtension == ".conflist" || fileExtension == ".conf" || fileExtension == ".json" {
+			confFiles = append(confFiles, file.Name())
+		}
+	}
+
+	if len(confFiles) == 0 {
+		return "", fmt.Errorf("no existing cni plugin configuration file found")
+	}
+	sort.Strings(confFiles)
+	return filepath.Join(cniConfDir, confFiles[0]), nil
+}
+
+func parseCidrs(cidrs string) ([]string, error) {
+	var res []string
+	cidrList := strings.Split(cidrs, ",")
+	for _, cidr := range cidrList {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		_, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("cidr %s is not valid: %w", cidr, err)
+		}
+		res = append(res, cidr)
+	}
+	return res, nil
+}

--- a/pkg/cni/conf/confmanager_test.go
+++ b/pkg/cni/conf/confmanager_test.go
@@ -1,0 +1,377 @@
+/*
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+*/
+package conf
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testDir      = "./testdata"
+	testConf     = "01-test.conf"
+	testConfList = "01-test.conflist"
+)
+
+func TestNewCNIConfManager(t *testing.T) {
+	tests := map[string]struct {
+		testDir        string
+		exceptionCidrs string
+		expectErr      bool
+		expectedCidrs  []string
+	}{
+		"NewCNIConfManager should report error when testDir does not exist": {
+			testDir:   "testdata1",
+			expectErr: true,
+		},
+		"NewCNIConfManager should report error when exceptionCidrs is not valid": {
+			testDir:        "testdata",
+			exceptionCidrs: "1000.1.2.3/32",
+			expectErr:      true,
+		},
+		"NewCNIConfManager should return manager as expected": {
+			testDir:        "testdata",
+			exceptionCidrs: "1.2.3.4/32,10.1.0.0/16",
+			expectedCidrs:  []string{"1.2.3.4/32", "10.1.0.0/16"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr, err := NewCNIConfManager(test.testDir, testConfList, test.exceptionCidrs)
+			defer func() {
+				if mgr != nil && mgr.cniConfWatcher != nil {
+					_ = mgr.cniConfWatcher.Close()
+				}
+			}()
+			if !test.expectErr {
+				if err != nil {
+					t.Fatalf("Got unexpected error when creating new cni conf manager: %v", err)
+				}
+				if mgr.cniConfDir != test.testDir {
+					t.Fatalf("mgr's cniConfDir is different: got: %s, expected: %s", mgr.cniConfDir, test.testDir)
+				}
+				if mgr.cniConfFile != testConfList {
+					t.Fatalf("mgr's cniConfFile is different: got: %s, expected: %s", mgr.cniConfFile, testConfList)
+				}
+				if mgr.cniConfWatcher == nil {
+					t.Fatalf("mgr's cniConfWatch is nil")
+				}
+				watches := mgr.cniConfWatcher.WatchList()
+				if !reflect.DeepEqual(watches, []string{test.testDir}) {
+					t.Fatalf("mgr's cniConfWatcher has unexpected watch list: got: %v, expected: %v", watches, []string{test.testDir})
+				}
+				if !reflect.DeepEqual(mgr.exceptionCidrs, test.expectedCidrs) {
+					t.Fatalf("mgr's exceptionCidrs is different: got: %v, expected: %v", mgr.exceptionCidrs, test.expectedCidrs)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("NewCNIConfManager does not return expected error")
+				}
+			}
+		})
+	}
+}
+
+func TestStart(t *testing.T) {
+	mgr, err := NewCNIConfManager(testDir, testConfList, "")
+	if err != nil {
+		t.Fatalf("failed to create cni conf manager: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer func() {
+		cancel()
+		wg.Wait()
+		_ = os.Remove(filepath.Join(testDir, testConfList))
+	}()
+	go func() {
+		defer wg.Done()
+		if err := mgr.Start(ctx); err != nil {
+			t.Errorf("test")
+		}
+	}()
+
+	// wait for 100 ms and check file
+	time.Sleep(100 * time.Millisecond)
+	file, err := os.Stat(filepath.Join(testDir, testConfList))
+	if err != nil {
+		t.Fatalf("failed to find cni conf file: %v", err)
+	}
+	creationTime := file.ModTime()
+
+	// create a random file
+	_, err = os.Create(filepath.Join(testDir, "test"))
+	if err != nil {
+		t.Fatalf("failed to create random file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(filepath.Join(testDir, "test"))
+	}()
+	time.Sleep(100 * time.Millisecond)
+	file, err = os.Stat(filepath.Join(testDir, testConfList))
+	if err != nil {
+		t.Fatalf("failed to find target file: %v", err)
+	}
+	if !file.ModTime().After(creationTime) {
+		t.Fatalf("cni conf file is not regenerated")
+	}
+
+	// delete existing cni conf file
+	_ = os.Remove(filepath.Join(testDir, testConfList))
+	time.Sleep(100 * time.Millisecond)
+	_, err = os.Stat(filepath.Join(testDir, testConfList))
+	if err != nil {
+		t.Fatalf("failed to find cni conf file: %v", err)
+	}
+}
+
+func TestInsertCNIPluginConf(t *testing.T) {
+	tests := map[string]struct {
+		confFile    string
+		testFile    string
+		expected    string
+		expectedErr bool
+	}{
+		"insertCNIPluginConf should insert new cni plugin configuration i conflist file as expected": {
+			confFile: "10-test.conflist",
+			testFile: testConfList,
+			expected: `{
+  "cniVersion": "0.3.1",
+  "name": "testnet",
+  "plugins": [
+    {
+      "addIf": "eth0",
+      "bridge": "cbr0",
+      "hairpinMode": false,
+      "ipMasq": false,
+      "ipam": {
+        "ranges": [
+          [
+            {
+              "subnet": "10.1.0.0/24"
+            }
+          ]
+        ],
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ],
+        "type": "host-local"
+      },
+      "isGateway": true,
+      "mtu": 1500,
+      "promiscMode": true,
+      "type": "bridge"
+    },
+    {
+      "excludedCIDRs": [
+        "10.1.0.0/16",
+        "1.2.3.4/32"
+      ],
+      "ipam": {
+        "type": "kube-egress-cni-ipam"
+      },
+      "type": "kube-egress-cni"
+    },
+    {
+      "capabilities": {
+        "portMappings": true
+      },
+      "externalSetMarkChain": "KUBE-MARK-MASQ",
+      "type": "portmap"
+    }
+  ]
+}`,
+		},
+		"insertCNIPluginConf should insert new cni plugin configuration in conf file as expected": {
+			confFile: "10-test.conf",
+			testFile: testConf,
+			expected: `{
+  "cniVersion": "0.3.1",
+  "name": "testnet",
+  "plugins": [
+    {
+      "addIf": "eth0",
+      "bridge": "cbr0",
+      "hairpinMode": false,
+      "ipMasq": false,
+      "ipam": {
+        "ranges": [
+          [
+            {
+              "subnet": "10.1.0.0/24"
+            }
+          ]
+        ],
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ],
+        "type": "host-local"
+      },
+      "isGateway": true,
+      "mtu": 1500,
+      "promiscMode": true,
+      "type": "bridge"
+    },
+    {
+      "excludedCIDRs": [
+        "10.1.0.0/16",
+        "1.2.3.4/32"
+      ],
+      "ipam": {
+        "type": "kube-egress-cni-ipam"
+      },
+      "type": "kube-egress-cni"
+    }
+  ]
+}`,
+		},
+		"insertCNIPluginConf should return error if existing conflist file has empty plugins": {
+			confFile:    "20-fake.conflist",
+			testFile:    testConfList,
+			expectedErr: true,
+		},
+		"insertCNIPluginConf should return error if existing conflist file does not have plugins": {
+			confFile:    "30-fake.conflist",
+			testFile:    testConfList,
+			expectedErr: true,
+		},
+		"insertCNIPluginConf should return error if existing plugin does not have type": {
+			confFile:    "40-fake.conflist",
+			testFile:    testConfList,
+			expectedErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			confFileName := "50-result.conflist"
+			mgr, err := NewCNIConfManager(testDir, confFileName, "10.1.0.0/16,1.2.3.4/32")
+			if err != nil {
+				t.Fatalf("failed to create cni conf manager: %v", err)
+			}
+			defer func() {
+				_ = mgr.cniConfWatcher.Close()
+			}()
+
+			if err := copyFile(testDir, test.confFile, test.testFile); err != nil {
+				t.Fatalf("failed to copy test files: %v", err)
+			}
+			defer func() {
+				_ = os.Remove(filepath.Join(testDir, test.testFile))
+				_ = os.Remove(filepath.Join(testDir, confFileName))
+			}()
+
+			err = mgr.insertCNIPluginConf()
+			if !test.expectedErr {
+				if err != nil {
+					t.Fatalf("insertCNIPluginConf returns unexpected err: %v", err)
+				}
+				bytes, err := os.ReadFile(filepath.Join(testDir, confFileName))
+				if err != nil {
+					t.Fatalf("failed to read result file: %v", err)
+				}
+				if string(bytes) != test.expected {
+					t.Fatalf("insertCNIPluginConf generated unexpected result: expected: %s, got: %s", test.expected, string(bytes))
+				}
+			} else if test.expectedErr {
+				if err == nil {
+					t.Fatalf("insertCNIPluginConf does not return expected err")
+				}
+			}
+		})
+	}
+}
+
+func TestParseCidrs(t *testing.T) {
+	tests := map[string]struct {
+		input       string
+		expected    []string
+		expectedErr bool
+	}{
+		"ParseCidrs should return nil when there's no cidr provided": {
+			input: "",
+		},
+		"ParseCidrs should return expected cidr when there's just one cidr provided": {
+			input:    "10.1.0.0/16",
+			expected: []string{"10.1.0.0/16"},
+		},
+		"ParseCidrs should return expected cidrs when there are multiple cidrs provided": {
+			input:    "10.1.0.0/16,1.2.3.4/32",
+			expected: []string{"10.1.0.0/16", "1.2.3.4/32"},
+		},
+		"ParseCidrs should trim spaces": {
+			input:    "   10.1.0.0/16  ,  1.2.3.4/32, 10.2.2.0/24,",
+			expected: []string{"10.1.0.0/16", "1.2.3.4/32", "10.2.2.0/24"},
+		},
+		"ParseCidrs should report error when an invalid cidr is provided": {
+			input:       "1000.2.3.4/32",
+			expectedErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := parseCidrs(test.input)
+			if !test.expectedErr {
+				if !reflect.DeepEqual(res, test.expected) {
+					t.Fatalf("parseCidrs does not expected result, expected: %#v, got: %#v", test.expected, res)
+				}
+				if err != nil {
+					t.Fatalf("parseCidrs returns unexpected error: %v", err)
+				}
+			} else if err == nil {
+				t.Fatal("parseCidrs does not return expected error")
+			}
+		})
+	}
+}
+
+func copyFile(dir, src, dest string) error {
+	sf, err := os.Open(filepath.Join(dir, src))
+	if err != nil {
+		return fmt.Errorf("failed to open src file: %w", err)
+	}
+	defer sf.Close()
+	df, err := os.Create(filepath.Join(dir, dest))
+	if err != nil {
+		return fmt.Errorf("failed to open dest file: %w", err)
+	}
+	defer df.Close()
+	_, err = io.Copy(df, sf)
+	if err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+	return nil
+}

--- a/pkg/cni/conf/testdata/10-test.conf
+++ b/pkg/cni/conf/testdata/10-test.conf
@@ -1,0 +1,17 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "testnet",
+    "type": "bridge",
+    "bridge": "cbr0",
+    "mtu": 1500,
+    "addIf": "eth0",
+    "isGateway": true,
+    "ipMasq": false,
+    "promiscMode": true,
+    "hairpinMode": false,
+    "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.1.0.0/24"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+    }
+}

--- a/pkg/cni/conf/testdata/10-test.conflist
+++ b/pkg/cni/conf/testdata/10-test.conflist
@@ -1,0 +1,24 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "testnet",
+    "plugins": [{
+    "type": "bridge",
+    "bridge": "cbr0",
+    "mtu": 1500,
+    "addIf": "eth0",
+    "isGateway": true,
+    "ipMasq": false,
+    "promiscMode": true,
+    "hairpinMode": false,
+    "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.1.0.0/24"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+    }
+    },
+    {
+    "type": "portmap",
+    "capabilities": {"portMappings": true},
+    "externalSetMarkChain": "KUBE-MARK-MASQ"
+    }]
+}

--- a/pkg/cni/conf/testdata/20-fake.conflist
+++ b/pkg/cni/conf/testdata/20-fake.conflist
@@ -1,0 +1,5 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "testnet",
+    "plugins": []
+}

--- a/pkg/cni/conf/testdata/30-fake.conflist
+++ b/pkg/cni/conf/testdata/30-fake.conflist
@@ -1,0 +1,4 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "testnet"
+}

--- a/pkg/cni/conf/testdata/40-fake.conflist
+++ b/pkg/cni/conf/testdata/40-fake.conflist
@@ -1,0 +1,18 @@
+{
+    "cniVersion": "0.3.1",
+    "name": "testnet",
+    "plugins": [{
+    "bridge": "cbr0",
+    "mtu": 1500,
+    "addIf": "eth0",
+    "isGateway": true,
+    "ipMasq": false,
+    "promiscMode": true,
+    "hairpinMode": false,
+    "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.1.0.0/24"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+    }
+    }]
+}

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -95,6 +95,8 @@ const (
 
 const (
 	CNISocketPath = "/var/run/egressgateway.sock"
+
+	CNIConfDir = "/etc/cni/net.d"
 )
 
 const (


### PR DESCRIPTION
Add a cniConfMgr in cniManager to create kube-egress-cni configuration and monitor /etc/cni/net.d changes.