### PR TITLE
update iptables distroless image

### DIFF
--- a/gwdaemon.Dockerfile
+++ b/gwdaemon.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/aks/devinfra/base-os-runtime-nettools:master.221105.1
+FROM baseosscr.azurecr.io/build-image/distroless-iptables-amd64:v0.1.2
 USER 0:0
 COPY --from=baseimg /${MAIN_ENTRY} .
 ENTRYPOINT [${MAIN_ENTRY}]


### PR DESCRIPTION
Update iptables distroless image to use iptables-nft in Ubuntu 22 and legacy iptables in old releases.