### PR TITLE
only build multi-arch image for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,10 +94,18 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
           bake-target: cni-ipam-tags
+      - name: Set platform env for pr build
+        run: |
+          echo "TARGET_PLATFORMS=linux/amd64" >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' }}
+      - name: Set platform env for release
+        run: |
+          echo "TARGET_PLATFORMS=linux/amd64,linux/arm64,linux/arm" >> $GITHUB_ENV
+        if: ${{ github.event_name != 'pull_request' }}
       - name: Build and push
         uses: docker/bake-action@v4
         env:
-          PLATFORMS: linux/amd64,linux/arm64,linux/arm
+          PLATFORMS: ${{env.TARGET_PLATFORMS}}
         with:
           push: ${{ github.event_name != 'pull_request' }}
           files: |

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ e2e-test: manifests generate fmt vet envtest ## Run e2e tests.
 
 IMAGE_REGISTRY ?= local
 IMAGE_TAG ?= $(shell git rev-parse --short=7 HEAD)
-TARGET_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm
+PLATFORMS ?= linux/amd64
+PLATFORMS_MULTI_ARCH ?= linux/amd64,linux/arm64,linux/arm
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
@@ -99,7 +100,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: unit-test docker-builder-setup ## Build docker image with the manager.
-	TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) PLATFORMS=$(TARGET_PLATFORMS) docker buildx bake -f docker-bake.hcl -f docker-localtag-bake.hcl --progress auto --push
+	TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) PLATFORMS=$(PLATFORMS) docker buildx bake -f docker-bake.hcl -f docker-localtag-bake.hcl --progress auto --push
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: unit-test docker-builder-setup ## Build docker image with the manager.
+	TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) PLATFORMS=$(PLATFORMS_MULTI_ARCH) docker buildx bake -f docker-bake.hcl -f docker-localtag-bake.hcl --progress auto --push
 
 .PHONY: docker-builder-setup
 docker-builder-setup:


### PR DESCRIPTION
Multi-arch build takes >40min in azure pipeline to complete and the whole e2e test exceeds the azure pipeline's limit, 1 hour. Only build linux/amd64 to reduce e2e pipeline duration.