### PR TITLE
fix: fix event object, lbbackendpool remove logic, node event

### DIFF
--- a/api/v1alpha1/gatewayvmconfiguration_types.go
+++ b/api/v1alpha1/gatewayvmconfiguration_types.go
@@ -46,8 +46,7 @@ type GatewayVMConfigurationStatus struct {
 
 // GatewayVMProfile provides details about gateway VM side configuration.
 type GatewayVMProfile struct {
-	NodeName string `json:"nodeName,omitempty"`
-	// todo: remove PrimaryIP once we change the routing logic to have everything configured in host network
+	NodeName    string `json:"nodeName,omitempty"`
 	PrimaryIP   string `json:"primaryIP,omitempty"`
 	SecondaryIP string `json:"secondaryIP,omitempty"`
 }

--- a/controllers/manager/staticgatewayconfiguration_controller.go
+++ b/controllers/manager/staticgatewayconfiguration_controller.go
@@ -136,8 +136,8 @@ func (r *StaticGatewayConfigurationReconciler) reconcile(
 		err := r.Update(ctx, gwConfig)
 		if err != nil {
 			log.Error(err, "failed to add finalizer")
+			return err
 		}
-		return err
 	}
 
 	_, err := controllerutil.CreateOrPatch(ctx, r, gwConfig, func() error {

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -15,6 +15,9 @@ const (
 	// Default gateway LoadBalancer name
 	DefaultGatewayLBName = "kubeegressgateway-ilb"
 
+	// Prefix for managed Azure resources (public IPPrefix, VMSS ipConfig, etc)
+	ManagedResourcePrefix = "egressgateway-"
+
 	// Key name in the wireugard private key secret
 	WireguardPrivateKeyName = "PrivateKey"
 


### PR DESCRIPTION
1. Associate all controller manager generated events to the `StaticGatewayConfiguration` object, instead of `GatewayLBConfiguration` or `GatewayVMConfiguration` objects to make them more visible to user.
2. Do not return after adding finalizer, continue reconciling
3. Only skip node event reconcile when node has nodepool tag, vmConfig specifies `GatewayNodepoolName` and the values do not match.