### PR TITLE
avoid using dockerHub for base images

### DIFF
--- a/.pipeline/e2e.yaml
+++ b/.pipeline/e2e.yaml
@@ -55,7 +55,7 @@ jobs:
       set -euo pipefail
       mv $(pwd)/azure.json $(pwd)/config/azureconfig/azure.json
       echo EXCEPTION_CIDRS=${POD_CIDR}","${SERVICE_CIDR} > $(pwd)/config/environment_variables/environment.env
-      IMAGE_REGISTRY=$(registry.url) make install
+      IMAGE_REGISTRY=$(registry.url) E2E_PIPELINE=true make install
       kubectl wait --for=condition=ready pod -A -l app=kube-egress-gateway --timeout=300s
       kubectl get all -n kube-egress-gateway-system
     displayName: build and install kube-egress-gateway components

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,13 @@ docker-build: docker-builder-setup ## Build docker image with the manager.
 
 .PHONY: docker-build-multi-arch
 docker-build-multi-arch: docker-builder-setup ## Build docker image with the manager.
-	TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) PLATFORMS=$(PLATFORMS_MULTI_ARCH) docker buildx bake -f docker/docker-bake.hcl -f  docker/docker-localtag-bake.hcl --progress auto --set=*.output=type=$(OUTPUT_TYPE)
+	TAG=$(IMAGE_TAG) IMAGE_REGISTRY=$(IMAGE_REGISTRY) PLATFORMS=$(PLATFORMS_MULTI_ARCH) docker buildx bake -f docker/docker-bake.hcl -f docker/docker-localtag-bake.hcl --progress auto --set=*.output=type=$(OUTPUT_TYPE)
 
 .PHONY: docker-builder-setup
 docker-builder-setup:
+ifndef E2E_PIPELINE
 	docker run --privileged --rm tonistiigi/binfmt --install all
+endif
 
 ##@ Deployment
 

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22 as builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22.5 as builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/docker/cni.Dockerfile
+++ b/docker/cni.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM alpine
+FROM mcr.microsoft.com/mirror/docker/library/alpine:3.16
 COPY --from=baseimg /kube* /
 USER 0:0
 ENTRYPOINT cp /kube* /opt/cni/bin/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Azure pipeline for e2e tests now fail at pretty high rate due to docker hub throttling. Remove all dependencies from dockerHub.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->