### PR TITLE
Add tolerations and nodeselector to gatewayCniManager and gatewayCont…

### DIFF
--- a/helm/kube-egress-gateway/README.md
+++ b/helm/kube-egress-gateway/README.md
@@ -88,6 +88,8 @@ Additionally, `common.gatewayLbProbePort` defines the gateway LoadBalancer probe
 | `gatewayControllerManager.leaderElect` | `true` | If multiple relicas are enabled for gatewayControllerManager, enable or disable leader Election among the relicas. Default to `true`. |
 | `gatewayControllerManager.metricsBindPort` | `8080` | Port that gatewayControllerManager listens on for `/metrics` requests. |
 | `gatewayControllerManager.healthProbeBindPort` | `8081` | Port that gatewayControllerManager listens on for health probe requests. |
+| `gatewayControllerManager.nodeSelector` | | Define tolerations to allow the pods to be scheduled on nodes with specific taints. |
+| `gatewayControllerManager.tolerations` | | Specify which nodes the pods should run on by providing matching labels. |
 
 ## gateway-daemon-manager configurations
 
@@ -114,6 +116,8 @@ Additionally, `common.gatewayLbProbePort` defines the gateway LoadBalancer probe
 | `gatewayCNIManager.cniConfigFileName` | `01-egressgateway.conflist` | Name of the newly generated cni configuration list file. |
 | `gatewayCNIManager.cniUninstallConfigMapName` | `cni-uninstall` | Name of the configMap indicating whether cni plugin needs to be uninstalled upon gatewayCNIManager pod shutdown. |
 | `gatewayCNIManager.cniUninstall` | `false` | Boolean indicating whether to uninstall kube-egress-gateway CNI plugin upon gatewayCNIManager pod shutdown. |
+| `gatewayCNIManager.nodeSelector` | `kubernetes.io/os: linux` | Define tolerations to allow the pods to be scheduled on nodes with specific taints. |
+| `gatewayCNIManager.tolerations` | | Specify which nodes the pods should run on by providing matching labels. |
 
 ## gateway-CNI and gateway-CNI-Ipam configurations
 

--- a/helm/kube-egress-gateway/templates/gateway-cni-manager.yaml
+++ b/helm/kube-egress-gateway/templates/gateway-cni-manager.yaml
@@ -159,8 +159,14 @@ spec:
         - mountPath: /opt/cni/bin
           name: cni-bin
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
+      {{- with .Values.gatewayCNIManager.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gatewayCNIManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: kube-egress-gateway-cni-manager
       terminationGracePeriodSeconds: 60 # update to 60 seconds for cni uninstall retry on error
       volumes:

--- a/helm/kube-egress-gateway/templates/gateway-controller-manager.yaml
+++ b/helm/kube-egress-gateway/templates/gateway-controller-manager.yaml
@@ -277,4 +277,12 @@ spec:
       - name: azure-cloud-config
         secret:
           secretName: kube-egress-gateway-azure-cloud-config
+      {{- with .Values.gatewayControllerManager.nodeSelector }}
+      nodeSelector: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gatewayControllerManager.tolerations }}
+      tolerations:
+       {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/kube-egress-gateway/values.yaml
+++ b/helm/kube-egress-gateway/values.yaml
@@ -13,6 +13,8 @@ gatewayControllerManager:
   leaderElect: "true"
   metricsBindPort: 8080
   healthProbeBindPort: 8081
+  nodeSelector: {}
+  tolerations: []
 
 gatewayCNIManager:
   enabled: true
@@ -26,6 +28,9 @@ gatewayCNIManager:
   cniConfigFileName: "01-egressgateway.conflist"
   cniUninstallConfigMapName: "cni-uninstall"
   cniUninstall: false
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations: []
 
 gatewayDaemonManager:
   enabled: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
feature

#### What this PR does / why we need it:

This PR introduces the ability to configure tolerations and nodeSelectors for both the cniManager and controllerManager. This feature is necessary because my infrastructure deployment requires the flexibility to customize these settings, and it would be beneficial for them to be optional.