### PR TITLE
fix egress Ip prefix readiness check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,5 @@ MigrationBackup/
 .idea/
 
 # config/daemon/manager/azure.json
+
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ MigrationBackup/
 # config/daemon/manager/azure.json
 
 vendor/
+localtest/

--- a/controllers/cnimanager/server.go
+++ b/controllers/cnimanager/server.go
@@ -40,7 +40,7 @@ func (s *NicService) NicAdd(ctx context.Context, in *cniprotocol.NicAddRequest) 
 	if err := s.k8sClient.Get(ctx, client.ObjectKey{Name: in.GetGatewayName(), Namespace: in.GetPodConfig().GetPodNamespace()}, gwConfig); err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to retrieve StaticGatewayConfiguration %s/%s: %s", in.GetPodConfig().GetPodNamespace(), in.GetGatewayName(), err)
 	}
-	if len(gwConfig.Status.Ip) == 0 {
+	if len(gwConfig.Status.EgressIpPrefix) == 0 {
 		return nil, status.Errorf(codes.FailedPrecondition, "the gateway is not ready yet.")
 	}
 	pod := &corev1.Pod{}

--- a/controllers/cnimanager/server.go
+++ b/controllers/cnimanager/server.go
@@ -41,7 +41,7 @@ func (s *NicService) NicAdd(ctx context.Context, in *cniprotocol.NicAddRequest) 
 		return nil, status.Errorf(codes.Unknown, "failed to retrieve StaticGatewayConfiguration %s/%s: %s", in.GetPodConfig().GetPodNamespace(), in.GetGatewayName(), err)
 	}
 	if len(gwConfig.Status.EgressIpPrefix) == 0 {
-		return nil, status.Errorf(codes.FailedPrecondition, "the gateway is not ready yet.")
+		return nil, status.Errorf(codes.FailedPrecondition, "the egress IP prefix is not ready yet.")
 	}
 	pod := &corev1.Pod{}
 	if err := s.k8sClient.Get(ctx, client.ObjectKey{Name: in.GetPodConfig().GetPodName(), Namespace: in.GetPodConfig().GetPodNamespace()}, pod); err != nil {

--- a/controllers/cnimanager/server_test.go
+++ b/controllers/cnimanager/server_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Server", func() {
 				Namespace: "default",
 			},
 			Status: current.StaticGatewayConfigurationStatus{
+				EgressIpPrefix: "13.66.156.240/30",
 				GatewayServerProfile: current.GatewayServerProfile{
 					Ip:        "192.168.1.1/32",
 					PublicKey: "somerandompublickey",

--- a/go.mod
+++ b/go.mod
@@ -135,26 +135,27 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+// add replace to workaround issue "invalid version: unknown revision v0.0.0" https://stackoverflow.com/questions/59187781/revision-v0-0-0-unknown-for-go-get-k8s-io-kubernetes
 replace (
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.31.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.31.2
-	k8s.io/component-helpers => k8s.io/component-helpers v0.31.2
-	k8s.io/controller-manager => k8s.io/controller-manager v0.31.2
-	k8s.io/cri-api => k8s.io/cri-api v0.31.2
-	k8s.io/cri-client => k8s.io/cri-client v0.31.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.31.2
-	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.31.2
-	k8s.io/endpointslice => k8s.io/endpointslice v0.31.2
-	k8s.io/externaljwt => k8s.io/externaljwt v0.31.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.31.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.31.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.31.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.31.2
-	k8s.io/kubectl => k8s.io/kubectl v0.31.2
-	k8s.io/kubelet => k8s.io/kubelet v0.31.2
-	k8s.io/metrics => k8s.io/metrics v0.31.2
-	k8s.io/mount-utils => k8s.io/mount-utils v0.31.2
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.31.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.31.2
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.0
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.0
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.0
+	k8s.io/component-helpers => k8s.io/component-helpers v0.32.0
+	k8s.io/controller-manager => k8s.io/controller-manager v0.32.0
+	k8s.io/cri-api => k8s.io/cri-api v0.32.0
+	k8s.io/cri-client => k8s.io/cri-client v0.32.0
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.0
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.0
+	k8s.io/endpointslice => k8s.io/endpointslice v0.32.0
+	k8s.io/externaljwt => k8s.io/externaljwt v0.32.0
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.0
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.0
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.0
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.0
+	k8s.io/kubectl => k8s.io/kubectl v0.32.0
+	k8s.io/kubelet => k8s.io/kubelet v0.32.0
+	k8s.io/metrics => k8s.io/metrics v0.32.0
+	k8s.io/mount-utils => k8s.io/mount-utils v0.32.0
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.0
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.0
 )

--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,27 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace (
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.31.2
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.2
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.31.2
+	k8s.io/component-helpers => k8s.io/component-helpers v0.31.2
+	k8s.io/controller-manager => k8s.io/controller-manager v0.31.2
+	k8s.io/cri-api => k8s.io/cri-api v0.31.2
+	k8s.io/cri-client => k8s.io/cri-client v0.31.2
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.31.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.31.2
+	k8s.io/endpointslice => k8s.io/endpointslice v0.31.2
+	k8s.io/externaljwt => k8s.io/externaljwt v0.31.2
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.31.2
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.31.2
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.31.2
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.31.2
+	k8s.io/kubectl => k8s.io/kubectl v0.31.2
+	k8s.io/kubelet => k8s.io/kubelet v0.31.2
+	k8s.io/metrics => k8s.io/metrics v0.31.2
+	k8s.io/mount-utils => k8s.io/mount-utils v0.31.2
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.31.2
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.31.2
+)

--- a/go.mod
+++ b/go.mod
@@ -134,28 +134,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-// add replace to workaround issue "invalid version: unknown revision v0.0.0" https://stackoverflow.com/questions/59187781/revision-v0-0-0-unknown-for-go-get-k8s-io-kubernetes
-replace (
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.0
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.0
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.0
-	k8s.io/component-helpers => k8s.io/component-helpers v0.32.0
-	k8s.io/controller-manager => k8s.io/controller-manager v0.32.0
-	k8s.io/cri-api => k8s.io/cri-api v0.32.0
-	k8s.io/cri-client => k8s.io/cri-client v0.32.0
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.0
-	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.0
-	k8s.io/endpointslice => k8s.io/endpointslice v0.32.0
-	k8s.io/externaljwt => k8s.io/externaljwt v0.32.0
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.0
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.0
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.0
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.0
-	k8s.io/kubectl => k8s.io/kubectl v0.32.0
-	k8s.io/kubelet => k8s.io/kubelet v0.32.0
-	k8s.io/metrics => k8s.io/metrics v0.32.0
-	k8s.io/mount-utils => k8s.io/mount-utils v0.32.0
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.0
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.0
-)

--- a/helm/kube-egress-gateway/README.md
+++ b/helm/kube-egress-gateway/README.md
@@ -15,7 +15,7 @@ $ helm install \
   --namespace kube-egress-gateway-system \
   --create-namespace \
   --set common.imageRepository=mcr.microsoft.com/aks \
-  --set common.imageTag=v0.0.14 \ 
+  --set common.imageTag=v0.0.14 \
   -f azure_config.yaml
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fix the logic to check the egress IP prefix, throw error when egress IP prefix is not ready/valid
Validated that when publicIpPrefixId refers to a nonexisting resource, the pod cannot get ready
![image](https://github.com/user-attachments/assets/bea8f09d-9754-4652-9b42-36579dbeedb1)
![image](https://github.com/user-attachments/assets/8a7a80a7-1174-4091-899b-6287a357c8d9)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->