### PR TITLE
handle failed VMSS instance update

### DIFF
--- a/controllers/manager/gatewayvmconfiguration_controller.go
+++ b/controllers/manager/gatewayvmconfiguration_controller.go
@@ -549,7 +549,7 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 	lbBackendpoolID string,
 	wantIPConfig bool,
 ) (string, error) {
-	log := log.FromContext(ctx)
+	log := log.FromContext(ctx).WithValues("vmssInstance", to.Val(vm.ID), "wantIPConfig", wantIPConfig, "ipPrefixID", ipPrefixID)
 	ipConfigName := managedSubresourceName(vmConfig)
 	vmssRG := getVMSSResourceGroup(vmConfig)
 
@@ -561,18 +561,12 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 	}
 
 	forceUpdate := false
-	// check LatestModelApplied
-	if vm.Properties.LatestModelApplied != nil && !to.Val(vm.Properties.LatestModelApplied) {
-		forceUpdate = true
-		log.Info("Force update for unexpected VMSS instance LatestModelApplied:false", "vmssInstance", to.Val(vm.ID))
-	}
-
 	// check ProvisioningState
-	if !forceUpdate && vm.Properties.ProvisioningState != nil && !strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Succeeded") {
+	if vm.Properties.ProvisioningState != nil && !strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Succeeded") {
 		log.Info(fmt.Sprintf("VMSS instance ProvisioningState %q", to.Val(vm.Properties.ProvisioningState)))
 		if strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Failed") {
 			forceUpdate = true
-			log.Info(fmt.Sprintf("Force update for unexpected VMSS instance ProvisioningState:%q", to.Val(vm.Properties.ProvisioningState)), "vmssInstance", to.Val(vm.ID))
+			log.Info(fmt.Sprintf("Force update for unexpected VMSS instance ProvisioningState:%q", to.Val(vm.Properties.ProvisioningState)))
 		}
 	}
 
@@ -612,7 +606,7 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 	}
 	vmUpdated := false
 	if needUpdate || forceUpdate {
-		log.Info("Updating vmss instance", "vmInstanceID", to.Val(vm.InstanceID))
+		log.Info("Updating vmss instance")
 		if !needUpdate && forceUpdate {
 			log.Info("Updating vmss instance triggered by forceUpdate")
 		}

--- a/controllers/manager/gatewayvmconfiguration_controller.go
+++ b/controllers/manager/gatewayvmconfiguration_controller.go
@@ -568,7 +568,7 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 	}
 
 	// check ProvisioningState
-	if vm.Properties.ProvisioningState != nil && !strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Succeeded") {
+	if !forceUpdate && vm.Properties.ProvisioningState != nil && !strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Succeeded") {
 		log.Info(fmt.Sprintf("VMSS instance ProvisioningState %q", to.Val(vm.Properties.ProvisioningState)))
 		if strings.EqualFold(to.Val(vm.Properties.ProvisioningState), "Failed") {
 			forceUpdate = true
@@ -578,7 +578,7 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 
 	// check primary IP & secondary IP
 	var primaryIP, secondaryIP string
-	if wantIPConfig {
+	if !forceUpdate && wantIPConfig {
 		for _, nic := range vm.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations {
 			if nic.Properties != nil && to.Val(nic.Properties.Primary) {
 				vmNic, err := r.GetVMSSInterface(ctx, vmssRG, vmssName, to.Val(vm.InstanceID), to.Val(nic.Name))

--- a/controllers/manager/gatewayvmconfiguration_controller.go
+++ b/controllers/manager/gatewayvmconfiguration_controller.go
@@ -583,7 +583,11 @@ func (r *GatewayVMConfigurationReconciler) reconcileVMSSVM(
 			if nic.Properties != nil && to.Val(nic.Properties.Primary) {
 				vmNic, err := r.GetVMSSInterface(ctx, vmssRG, vmssName, to.Val(vm.InstanceID), to.Val(nic.Name))
 				if err != nil || vmNic.Properties == nil || vmNic.Properties.IPConfigurations == nil {
-					log.Info("Skip IP check for forceUpdate")
+					if err != nil {
+						log.Info("Skip IP check for forceUpdate", "error", err.Error())
+					} else {
+						log.Info("Skip IP check for forceUpdate")
+					}
 					break
 				}
 				for _, ipConfig := range vmNic.Properties.IPConfigurations {

--- a/controllers/manager/gatewayvmconfiguration_controller_test.go
+++ b/controllers/manager/gatewayvmconfiguration_controller_test.go
@@ -604,10 +604,13 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				existingVMSS := getEmptyVMSS()
 				expectedVMSS := getConfiguredVMSS()
 				mockVMSSClient := az.VmssClient.(*mock_virtualmachinescalesetclient.MockInterface)
+				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), vmssRG, vmssName, gomock.Any()).Return(expectedVMSS, nil)
 				mockVMSSVMClient := az.VmssVMClient.(*mock_virtualmachinescalesetvmclient.MockInterface)
 				vms := []*compute.VirtualMachineScaleSetVM{getEmptyVMSSVM()}
 				mockVMSSVMClient.EXPECT().List(gomock.Any(), vmssRG, vmssName).Return(vms, nil)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
+					getNotReadyVMSSVMInterface(), nil)
 				mockVMSSVMClient.EXPECT().Update(gomock.Any(), vmssRG, vmssName, "0", gomock.Any()).Return(nil, fmt.Errorf("failed"))
 				_, err := r.reconcileVMSS(context.TODO(), vmConfig, existingVMSS, "prefix", true)
 				Expect(errors.Unwrap(err)).To(Equal(fmt.Errorf("failed")))
@@ -617,6 +620,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				existingVMSS := getEmptyVMSS()
 				expectedVMSS := getConfiguredVMSS()
 				mockVMSSClient := az.VmssClient.(*mock_virtualmachinescalesetclient.MockInterface)
+				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), vmssRG, vmssName, gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName string, vmss compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
 						Expect(vmss).To(Equal(to.Val(expectedVMSS)))
@@ -627,6 +631,8 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				vms := []*compute.VirtualMachineScaleSetVM{getEmptyVMSSVM()}
 				expectedVM := getConfiguredVMSSVM()
 				mockVMSSVMClient.EXPECT().List(gomock.Any(), vmssRG, vmssName).Return(vms, nil)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
+					getNotReadyVMSSVMInterface(), nil)
 				mockVMSSVMClient.EXPECT().Update(gomock.Any(), vmssRG, vmssName, "0", gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName, instanceID string, vm compute.VirtualMachineScaleSetVM) (*compute.VirtualMachineScaleSetVM, error) {
 						// during update, we don't fill in vm.OSProfile. Fill in here for test purpose
@@ -637,7 +643,6 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						expectedVM.InstanceID = to.Ptr("0")
 						return expectedVM, nil
 					})
-				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
 					getConfiguredVMSSVMInterface(), nil)
 				_, err := r.reconcileVMSS(context.TODO(), vmConfig, existingVMSS, "prefix", true)
@@ -663,6 +668,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				existingVMSS.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations[0].
 					Properties.IPConfigurations[1].Properties.PrivateIPAddressVersion = to.Ptr(compute.IPVersionIPv6)
 				mockVMSSClient := az.VmssClient.(*mock_virtualmachinescalesetclient.MockInterface)
+				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), vmssRG, vmssName, gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName string, vmss compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
 						Expect(vmss).To(Equal(to.Val(expectedVMSS)))
@@ -676,6 +682,8 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 					Properties.IPConfigurations[1].Properties.PrivateIPAddressVersion = to.Ptr(compute.IPVersionIPv6)
 				vms := []*compute.VirtualMachineScaleSetVM{existingVM}
 				mockVMSSVMClient.EXPECT().List(gomock.Any(), vmssRG, vmssName).Return(vms, nil)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
+					getNotReadyVMSSVMInterface(), nil)
 				mockVMSSVMClient.EXPECT().Update(gomock.Any(), vmssRG, vmssName, "0", gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName, instanceID string, vm compute.VirtualMachineScaleSetVM) (*compute.VirtualMachineScaleSetVM, error) {
 						// during update, we don't fill in vm.OSProfile. Fill in here for test purpose
@@ -686,7 +694,6 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						expectedVM.InstanceID = to.Ptr("0")
 						return expectedVM, nil
 					})
-				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
 					getConfiguredVMSSVMInterface(), nil)
 				_, err := r.reconcileVMSS(context.TODO(), vmConfig, existingVMSS, "prefix", true)
@@ -734,6 +741,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 			It("should configure vmss and vm without publicIPConfiguration and return vmss instance private IPs when ipPrefixID is empty", func() {
 				existingVMSS, expectedVMSS := getEmptyVMSS(), getConfiguredVMSSWithoutPublicIPConfig()
 				mockVMSSClient := az.VmssClient.(*mock_virtualmachinescalesetclient.MockInterface)
+				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), vmssRG, vmssName, gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName string, vmss compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
 						Expect(vmss).To(Equal(to.Val(expectedVMSS)))
@@ -744,6 +752,8 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				vms := []*compute.VirtualMachineScaleSetVM{getEmptyVMSSVM()}
 				expectedVM := getConfiguredVMSSVMWithoutPublicIPConfig()
 				mockVMSSVMClient.EXPECT().List(gomock.Any(), vmssRG, vmssName).Return(vms, nil)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
+					getNotReadyVMSSVMInterface(), nil)
 				mockVMSSVMClient.EXPECT().Update(gomock.Any(), vmssRG, vmssName, "0", gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName, instanceID string, vm compute.VirtualMachineScaleSetVM) (*compute.VirtualMachineScaleSetVM, error) {
 						// during update, we don't fill in vm.OSProfile. Fill in here for test purpose
@@ -754,7 +764,6 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						expectedVM.InstanceID = to.Ptr("0")
 						return expectedVM, nil
 					})
-				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
 					getConfiguredVMSSVMInterface(), nil)
 				privateIPs, err := r.reconcileVMSS(context.TODO(), vmConfig, existingVMSS, "", true)
@@ -766,6 +775,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 			It("should remove vmss and vm publicIPConfiguration and return vmss instance private IPs when ipPrefixID is updated to be empty", func() {
 				existingVMSS, expectedVMSS := getConfiguredVMSSWithNameAndUID(), getConfiguredVMSSWithoutPublicIPConfig()
 				mockVMSSClient := az.VmssClient.(*mock_virtualmachinescalesetclient.MockInterface)
+				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockVMSSClient.EXPECT().CreateOrUpdate(gomock.Any(), vmssRG, vmssName, gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName string, vmss compute.VirtualMachineScaleSet) (*compute.VirtualMachineScaleSet, error) {
 						Expect(vmss).To(Equal(to.Val(expectedVMSS)))
@@ -778,6 +788,8 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				vms := []*compute.VirtualMachineScaleSetVM{existingVM}
 				expectedVM := getConfiguredVMSSVMWithoutPublicIPConfig()
 				mockVMSSVMClient.EXPECT().List(gomock.Any(), vmssRG, vmssName).Return(vms, nil)
+				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
+					getNotReadyVMSSVMInterface(), nil)
 				mockVMSSVMClient.EXPECT().Update(gomock.Any(), vmssRG, vmssName, "0", gomock.Any()).
 					DoAndReturn(func(ctx context.Context, rg, vmssName, instanceID string, vm compute.VirtualMachineScaleSetVM) (*compute.VirtualMachineScaleSetVM, error) {
 						// during update, we don't fill in vm.OSProfile. Fill in here for test purpose
@@ -788,7 +800,6 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						expectedVM.InstanceID = to.Ptr("0")
 						return expectedVM, nil
 					})
-				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().GetVirtualMachineScaleSetNetworkInterface(gomock.Any(), vmssRG, vmssName, "0", "nic").Return(
 					getConfiguredVMSSVMInterface(), nil)
 				privateIPs, err := r.reconcileVMSS(context.TODO(), vmConfig, existingVMSS, "", true)
@@ -1266,6 +1277,28 @@ func getConfiguredVMSSVMInterface() *network.Interface {
 					Name: to.Ptr("egressgateway-testUID"),
 					Properties: &network.InterfaceIPConfigurationPropertiesFormat{
 						PrivateIPAddress: to.Ptr("10.0.0.6"),
+					},
+				},
+				{
+					Name: to.Ptr("primary"),
+					Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+						Primary:          to.Ptr(true),
+						PrivateIPAddress: to.Ptr("10.0.0.5"),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getNotReadyVMSSVMInterface() *network.Interface {
+	return &network.Interface{
+		Properties: &network.InterfacePropertiesFormat{
+			IPConfigurations: []*network.InterfaceIPConfiguration{
+				{
+					Name: to.Ptr("egressgateway-testUID"),
+					Properties: &network.InterfaceIPConfigurationPropertiesFormat{
+						PrivateIPAddress: nil,
 					},
 				},
 				{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Updating vmss instance failure is not retried if it happens. Make sure each reconciliation updates vmss instance if vm's state is not expected, or missing required primary IP and secondary IP.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #981


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->