### PR TITLE
cve: fix CVE-2025-22871 - bump go to 1.24.3

### DIFF
--- a/.pipeline/e2e.yaml
+++ b/.pipeline/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
   steps:
   - task: GoTool@0
     inputs:
-      version: '1.23.7'
+      version: '1.24.3'
   - bash: |
       echo $(registry.password) | docker login $(registry.url) -u $(registry.username) --password-stdin
     displayName: docker login

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.23.9@sha256:c705d51664f5057656a05df694f72990e19ff8089f7e184d37a8a1893e313bd7 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.3@sha256:d571b7d657aa472c7b49f143ea1942996240933cee257e37c3e4a4475b8ec567 AS builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kube-egress-gateway
 
-go 1.23.7
+go 1.23.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kube-egress-gateway
 
-go 1.23.9
+go 1.24.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
bump go to 1.23.9 to fix https://github.com/Azure/kube-egress-gateway/security/code-scanning/104


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->