### PR TITLE
fix: add `cwd://` to docker-bake files

### DIFF
--- a/.github/workflows/build-and-pusblish-mcr.yml
+++ b/.github/workflows/build-and-pusblish-mcr.yml
@@ -113,10 +113,10 @@ jobs:
           push: true
           files: |
             docker/docker-bake.hcl
-            ${{ steps.daemon.outputs.bake-file }}
-            ${{ steps.daemoninit.outputs.bake-file }}
-            ${{ steps.controller.outputs.bake-file }}
-            ${{ steps.cnimanager.outputs.bake-file }}
-            ${{ steps.cniplugin.outputs.bake-file }}
-            ${{ steps.cniipamplugin.outputs.bake-file }}
+            cwd://${{ steps.daemon.outputs.bake-file }}
+            cwd://${{ steps.daemoninit.outputs.bake-file }}
+            cwd://${{ steps.controller.outputs.bake-file }}
+            cwd://${{ steps.cnimanager.outputs.bake-file }}
+            cwd://${{ steps.cniplugin.outputs.bake-file }}
+            cwd://${{ steps.cniipamplugin.outputs.bake-file }}
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

this is the same fix applied for build.yml [here](https://github.com/Azure/kube-egress-gateway/pull/933/commits/1e37ad6e48e38258a8ad4b8be7d4a2f881e3a57f)

needed since we moved to bake-action v6 https://github.com/docker/bake-action/releases/tag/v6.0.0
