### PR TITLE
Update Go version to 1.25.0

### DIFF
--- a/.pipeline/templates/e2e-steps.yml
+++ b/.pipeline/templates/e2e-steps.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: goVersion
   type: string
-  default: '1.24.3'
+  default: '1.25.0'
 - name: podCidr
   type: string
   default: '10.244.0.0/16'

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.6@sha256:aad3eb77b1d422f5b11ebf8e9bef04146ff7206ab8c319bab33078a27746e500 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0 AS builder
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kube-egress-gateway
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0


### PR DESCRIPTION
#### What type of PR is this?

/kind chore

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
- Update go.mod to specify Go 1.25.0
- Update base.Dockerfile to use golang:1.25.0 image
- Update Azure pipeline e2e-steps.yml default Go version parameter
- GitHub workflows will automatically pick up new version from go.mod

#### Special notes for your reviewer

