### PR TITLE
Christine dossa/update go 1.25.0

### DIFF
--- a/.github/workflows/aks-e2e.yml
+++ b/.github/workflows/aks-e2e.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.25.0'
 
       - name: Create AKS cluster
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,4 +110,3 @@ jobs:
             cwd://${{ steps.cnimanager.outputs.bake-file }}
             cwd://${{ steps.cniplugin.outputs.bake-file }}
             cwd://${{ steps.cniipamplugin.outputs.bake-file }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-<<<<<<< HEAD
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
-=======
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
->>>>>>> 174890a (Update build.yml)
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,11 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
+<<<<<<< HEAD
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+=======
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+>>>>>>> 174890a (Update build.yml)
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,5 @@ jobs:
         with:
             # Use latest version to ensure Go 1.25 compatibility
           version: latest
-          # Skip cache to avoid version conflicts during Go upgrade
-          skip-cache: true
           # Optional: golangci-lint command line arguments.
           args: -v --timeout 10m ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,8 +30,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+            # Use latest version to ensure Go 1.25 compatibility
           version: latest
-
+          # Skip cache to avoid version conflicts during Go upgrade
+          skip-cache: true
           # Optional: golangci-lint command line arguments.
           args: -v --timeout 10m ./...

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 .PHONY: golangci-lint 
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v2.2.1
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) v2.4.0
 
 PROTOC_GEN_GO ?= $(LOCALBIN)/protoc-gen-go
 .PHONY: protoc-gen-go

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -19,6 +19,7 @@ ARG TARGETARCH
 FROM builder AS base
 WORKDIR /workspace
 # Build
+ENV GOEXPERIMENT=nosystemcrypto
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o ${MAIN_ENTRY}  ./cmd/${MAIN_ENTRY}/main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0@sha256:bc80e596d83c1506dae76301f6b5e11218fbbd3c0ed3d6f14c8c0dbd7a18b7d7 AS builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -19,8 +19,7 @@ ARG TARGETARCH
 FROM builder AS base
 WORKDIR /workspace
 # Build
-ENV GOEXPERIMENT=nosystemcrypto
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o ${MAIN_ENTRY}  ./cmd/${MAIN_ENTRY}/main.go
+RUN GOEXPERIMENT=nosystemcrypto CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o ${MAIN_ENTRY}  ./cmd/${MAIN_ENTRY}/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0@sha256:332a21b464204b651ebb12367104aca4c6a460b08d5e39182ae3d3eb349626c9 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0 AS builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0@sha256:bc80e596d83c1506dae76301f6b5e11218fbbd3c0ed3d6f14c8c0dbd7a18b7d7 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0@sha256:332a21b464204b651ebb12367104aca4c6a460b08d5e39182ae3d3eb349626c9 AS builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.7@sha256:08329e0d23110a75f197b91773fd6859060c13ec4418792e36eb6b472e9fef77 AS builder 
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.25.0@sha256:332a21b464204b651ebb12367104aca4c6a460b08d5e39182ae3d3eb349626c9 AS builder 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/kube-egress-gateway
 
-go 1.24.6
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0


### PR DESCRIPTION
What type of PR is this?
/kind chore

What this PR does / why we need it:
Which issue(s) this PR fixes:
Update go.mod to specify Go 1.25.0
Update base.Dockerfile to use golang:1.25.0 image
Update Azure pipeline e2e-steps.yml default Go version parameter
GitHub workflows will automatically pick up new version from go.mod

## Why bump golangci-lint to 2.4.0?

`v2.4.0` explicitly adds **Go 1.25 support**, plus a few linter updates/fixes.  
Release notes: https://golangci-lint.run/docs/product/changelog/#v240

### Why set `GOEXPERIMENT=nosystemcrypto`?

Starting with Go **1.25**, the **Microsoft build of Go** enables *system-provided cryptography by default* (OpenSSL on Linux, CNG on Windows). On **Linux**, this “systemcrypto” backend **requires cgo** and introduces a runtime dependency on the system’s crypto/glibc stack. Our container build explicitly sets `CGO_ENABLED=0` to produce a static, distroless-friendly binary. To keep those properties (no cgo, no external crypto linkage) and ensure consistent crypto behavior across our Linux images, we **opt-out** of the default with: `GOEXPERIMENT=nosystemcrypto` . This preserves the pre-1.25 behavior (pure Go crypto), avoids unexpected build/runtime linkage to OpenSSL/glibc in minimal images, and keeps our current supply-chain/compatibility assumptions intact: https://devblogs.microsoft.com/go/microsoft-go-defaults-to-system-crypto/

## Special notes for your reviewer: