### PR TITLE
fix: VM agent pools do not delete public IPs automatically

### DIFF
--- a/controllers/manager/agentpoolvms.go
+++ b/controllers/manager/agentpoolvms.go
@@ -250,9 +250,6 @@ func (r *agentPoolVMs) reconcileNIC(
 
 	// return earlier if it's deleting event
 	if !wantIPConfig {
-		if ipPrefixID != "" {
-			return "", r.DeletePublicIP(ctx, "", to.Val(nic.Name)) // todo does this error on not found?
-		}
 		return "", nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

when a gateway config is being deleted and the IP config on the NIC is being removed, the public IP associated to the NIC will persist even after the NIC is updated. In order to successfully remove the IP prefix the public IPs must be deleted individually first otherwise ARM will return `InUsePublicIpPrefixCannotBeDeleted`.