### PR TITLE
fix: public IPs need to be unique per config

### DIFF
--- a/controllers/manager/agentpoolvms.go
+++ b/controllers/manager/agentpoolvms.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/google/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -174,8 +176,13 @@ func (r *agentPoolVMs) reconcileNIC(
 				PublicIPAllocationMethod: to.Ptr(network.IPAllocationMethodStatic),
 			},
 		}
+		pipName, err := r.buildPublicIPName(ipPrefixID, to.Val(nic.Name))
+		if err != nil {
+			return "", err
+		}
+
 		// todo how do we handle if the publicIPPrefix is out of IPs?
-		pip, err := r.CreateOrUpdatePublicIP(ctx, "", to.Val(nic.Name), *expectedPublicIP)
+		pip, err := r.CreateOrUpdatePublicIP(ctx, "", pipName, *expectedPublicIP)
 		if err != nil {
 			return "", err
 		}
@@ -278,6 +285,19 @@ func (r *agentPoolVMs) reconcileNIC(
 	vmConfig.Status.GatewayVMProfiles = append(vmConfig.Status.GatewayVMProfiles, vmprofile)
 
 	return ipCfg.secondaryIP, nil
+}
+
+func (a *agentPoolVMs) buildPublicIPName(id string, val string) (string, error) {
+	ipPrefix, err := arm.ParseResourceID(id)
+	if err != nil {
+		return "", err
+	}
+	h := fnv.New64a()
+	_, err = h.Write([]byte(val))
+	if err != nil {
+		return "", err
+	}
+	return ipPrefix.Name + fmt.Sprintf("-%x", h.Sum64()), nil
 }
 
 func differentNIC(a, b *network.InterfaceIPConfiguration) bool {

--- a/controllers/manager/agentpoolvms_test.go
+++ b/controllers/manager/agentpoolvms_test.go
@@ -268,3 +268,142 @@ func TestDifferentNIC(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildPublicIPName(t *testing.T) {
+	tests := []struct {
+		name        string
+		ipPrefixID  string
+		nicName     string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:       "valid resource ID and NIC name",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "aks-nodepool1-12345678-vmss000000",
+			expected:   "test-prefix-65d70f8df610e8df", // Expected hash for this input
+		},
+		{
+			name:       "different NIC name generates different hash",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "aks-nodepool1-12345678-vmss000001",
+			expected:   "test-prefix-65d70e8df610e72c", // Different hash for different input
+		},
+		{
+			name:       "same inputs generate same hash (deterministic)",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "aks-nodepool1-12345678-vmss000000",
+			expected:   "test-prefix-65d70f8df610e8df", // Same as first test
+		},
+		{
+			name:       "different prefix name with same NIC",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/another-prefix",
+			nicName:    "aks-nodepool1-12345678-vmss000000",
+			expected:   "another-prefix-65d70f8df610e8df", // Same hash, different prefix
+		},
+		{
+			name:        "invalid resource ID format",
+			ipPrefixID:  "invalid-resource-id",
+			nicName:     "aks-nodepool1-12345678-vmss000000",
+			expectError: true,
+		},
+		{
+			name:        "empty resource ID",
+			ipPrefixID:  "",
+			nicName:     "aks-nodepool1-12345678-vmss000000",
+			expectError: true,
+		},
+		{
+			name:       "empty NIC name",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "",
+			expected:   "test-prefix-cbf29ce484222325", // Hash of empty string
+		},
+		{
+			name:       "long NIC name",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "very-long-nic-name-that-could-be-generated-in-some-scenarios-with-many-characters",
+			expected:   "test-prefix-466e8d0aab442712", // Hash handles long strings
+		},
+		{
+			name:       "NIC name with special characters",
+			ipPrefixID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix",
+			nicName:    "aks-nodepool1_test-vm.example",
+			expected:   "test-prefix-cfafa91a0f6d073b", // Hash handles special characters
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &agentPoolVMs{}
+			result, err := a.buildPublicIPName(tt.ipPrefixID, tt.nicName)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("buildPublicIPName() expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("buildPublicIPName() unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("buildPublicIPName() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildPublicIPNameConsistency(t *testing.T) {
+	a := &agentPoolVMs{}
+	ipPrefixID := "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix"
+	nicName := "aks-nodepool1-12345678-vmss000000"
+
+	// Call the function multiple times to ensure it's deterministic
+	results := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		result, err := a.buildPublicIPName(ipPrefixID, nicName)
+		if err != nil {
+			t.Fatalf("buildPublicIPName() unexpected error on iteration %d: %v", i, err)
+		}
+		results[i] = result
+	}
+
+	// All results should be identical
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			t.Errorf("buildPublicIPName() not consistent: iteration %d = %v, iteration 0 = %v", i, results[i], results[0])
+		}
+	}
+}
+
+func TestBuildPublicIPNameHashCollision(t *testing.T) {
+	a := &agentPoolVMs{}
+	ipPrefixID := "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg-test/providers/Microsoft.Network/publicIPPrefixes/test-prefix"
+
+	// Test different inputs to ensure they generate different hashes
+	nicNames := []string{
+		"aks-nodepool1-12345678-vmss000000",
+		"aks-nodepool1-12345678-vmss000001",
+		"aks-nodepool2-12345678-vmss000000",
+		"different-nic-name",
+	}
+
+	results := make(map[string]string)
+
+	for _, nicName := range nicNames {
+		result, err := a.buildPublicIPName(ipPrefixID, nicName)
+		if err != nil {
+			t.Fatalf("buildPublicIPName() unexpected error for nicName %s: %v", nicName, err)
+		}
+
+		if existingNic, exists := results[result]; exists {
+			t.Errorf("Hash collision detected: nicName %s and %s both generated %s", nicName, existingNic, result)
+		}
+
+		results[result] = nicName
+	}
+}

--- a/controllers/manager/gatewayvmconfiguration_controller_test.go
+++ b/controllers/manager/gatewayvmconfiguration_controller_test.go
@@ -40,8 +40,9 @@ import (
 )
 
 const (
-	vmssName = "vmss"
-	vmssRG   = "vmssRG"
+	vmssName                 = "vmss"
+	vmssRG                   = "vmssRG"
+	publicIPPrefixResourceID = "/subscriptions/516f20a4-a489-11f0-ac7f-8f4e0bcfbc5d/resourceGroups/MC_testcluster/providers/Microsoft.Network/publicIPPrefixes/publicipprefix-n"
 )
 
 var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
@@ -1015,7 +1016,10 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().List(gomock.Any(), testRG).Return(nics, nil)
 				mockPublicIPClient := az.PublicIPClient.(*mock_publicipaddressclient.MockInterface)
-				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, "nic2", gomock.Any()).Return(&network.PublicIPAddress{
+				pipName, err := poolVMs.buildPublicIPName(publicIPPrefixResourceID, *nics[1].Name)
+				Expect(err).NotTo(HaveOccurred())
+
+				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, pipName, gomock.Any()).Return(&network.PublicIPAddress{
 					Properties: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: to.Ptr("1.2.3.4"),
 					},
@@ -1031,7 +1035,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						},
 					},
 				}, nil)
-				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, "prefix", true)
+				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, publicIPPrefixResourceID, true)
 				Expect(err).To(BeNil())
 				Expect(len(ips)).To(Equal(1))
 			})
@@ -1070,7 +1074,10 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().List(gomock.Any(), testRG).Return(nics, nil)
 				mockPublicIPClient := az.PublicIPClient.(*mock_publicipaddressclient.MockInterface)
-				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, "nic2", gomock.Any()).Return(&network.PublicIPAddress{
+				pipName, err := poolVMs.buildPublicIPName(publicIPPrefixResourceID, *nics[1].Name)
+				Expect(err).NotTo(HaveOccurred())
+
+				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, pipName, gomock.Any()).Return(&network.PublicIPAddress{
 					Properties: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: to.Ptr("1.2.3.4"),
 					},
@@ -1086,7 +1093,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						},
 					},
 				}, nil)
-				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, "prefix", true)
+				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, publicIPPrefixResourceID, true)
 				Expect(err).To(BeNil())
 				Expect(len(ips)).To(Equal(1))
 			})
@@ -1119,7 +1126,10 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().List(gomock.Any(), testRG).Return(nics, nil)
 				mockPublicIPClient := az.PublicIPClient.(*mock_publicipaddressclient.MockInterface)
-				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, "gateway-nic", gomock.Any()).Return(&network.PublicIPAddress{
+				pipName, err := poolVMs.buildPublicIPName(publicIPPrefixResourceID, *nics[0].Name)
+				Expect(err).NotTo(HaveOccurred())
+
+				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, pipName, gomock.Any()).Return(&network.PublicIPAddress{
 					Properties: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: to.Ptr("1.2.3.4"),
 					},
@@ -1135,7 +1145,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						nic.Properties.IPConfigurations[1].Properties.PrivateIPAddress = to.Ptr("10.0.0.2")
 						return &nic, nil
 					})
-				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, "prefix", true)
+				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, publicIPPrefixResourceID, true)
 				Expect(err).To(BeNil())
 				Expect(len(ips)).To(Equal(1))
 				Expect(ips[0]).To(Equal("10.0.0.2"))
@@ -1176,7 +1186,10 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				mockInterfaceClient := az.InterfaceClient.(*mock_interfaceclient.MockInterface)
 				mockInterfaceClient.EXPECT().List(gomock.Any(), testRG).Return(nics, nil)
 				mockPublicIPClient := az.PublicIPClient.(*mock_publicipaddressclient.MockInterface)
-				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, "gateway-nic", gomock.Any()).Return(&network.PublicIPAddress{
+				pipName, err := poolVMs.buildPublicIPName(publicIPPrefixResourceID, *nics[0].Name)
+				Expect(err).NotTo(HaveOccurred())
+
+				mockPublicIPClient.EXPECT().CreateOrUpdate(gomock.Any(), testRG, pipName, gomock.Any()).Return(&network.PublicIPAddress{
 					Properties: &network.PublicIPAddressPropertiesFormat{
 						IPAddress: to.Ptr("1.2.3.4"),
 					},
@@ -1193,7 +1206,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 						nic.Properties.IPConfigurations[1].Properties.PrivateIPAddress = to.Ptr("10.0.0.2")
 						return &nic, nil
 					})
-				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, "prefix", true)
+				ips, err := poolVMs.Reconcile(context.Background(), vmConfig, publicIPPrefixResourceID, true)
 				Expect(err).To(BeNil())
 				Expect(len(ips)).To(Equal(1))
 				Expect(ips[0]).To(Equal("10.0.0.2"))


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

make naming of public IPs unique to each gateway configuration, otherwise each config used in VM agent pools will collide on the public IP names.

The implementation is to use the publicIP prefix name + a 64bit hash of the name of the NIC it is being assigned to.
