### PR TITLE
update docs to reflect support for private ip seg

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -61,4 +61,100 @@ kube-egress-gateway components communicates with Azure Resource Manager (ARM) to
     ```
 
 ## Install kube-egress-gateway as Helm Chart
-See details [here](../helm/kube-egress-gateway/README.md). 
+See details [here](../helm/kube-egress-gateway/README.md).
+
+## Configuration Options
+
+### Public IP vs Private IP Egress
+
+kube-egress-gateway always provisions private IPs on gateway nodes as secondary IP configurations. The `provisionPublicIps` setting controls whether *additional* public IP prefix resources are created and associated with these private IPs. This gives you flexibility in how pods egress:
+
+#### Public IP Mode (Default)
+
+In this mode (`provisionPublicIps: true`), public IP prefix resources are created and associated with the gateway nodes, enabling pods to access the Internet with fixed public egress IPs.
+
+**Use cases:**
+* Pods need to access external Internet services
+* External systems require allowlisting specific public IP addresses
+* Outbound Internet connectivity with a fixed, predictable source IP is required
+
+**Configuration:**
+```yaml
+spec:
+  gatewayVmssProfile:
+    vmssResourceGroup: myResourceGroup
+    vmssName: myGatewayVMSS
+    publicIpPrefixSize: 31
+  provisionPublicIps: true  # Default value
+  publicIpPrefixId: /subscriptions/.../publicIPPrefixes/myPIPPrefix  # Optional BYO
+```
+
+#### Private IP Only Mode
+
+In this mode (`provisionPublicIps: false`), no public IP prefix resources are created. Pods egress using only the private IPs that are allocated on the gateway nodes.
+
+**Requirements:**
+* **VM-based gateway nodepool** (`gatewayNodepoolName`) is **required** - This mode is NOT supported with VMSS-based gateways (`gatewayVmssProfile`)
+* **Kubernetes version ≥ 1.34** is required for VM gateway pool support
+* Properly sized gateway subnet (see subnet requirements below)
+
+> **Why VM gateway pools for private IP mode?**
+>
+> Private static IP egress requires deterministic IP assignment that remains stable across node scale operations and upgrades. VM-based gateway pools achieve this through:
+> * **Pre-created NICs**: NICs are created upfront (up to the pool's max size), allowing the controller to write secondary `ipConfigurations[]` that pin private IPs to specific nodes
+> * **IP stability**: Secondary IPs stick with each node across restarts and are preserved through rolling operations, avoiding source IP drift
+> * **Predictable state**: This design enables validation that secondary IPs remain unchanged after upgrades, critical for allowlisting scenarios
+>
+> In contrast, VMSS-based pools were designed for dynamic ipConfigs tied to public IP prefixes and don't provide the same IP stability guarantees.
+
+**Subnet sizing requirements:**
+
+The gateway subnet must have enough free IP addresses for:
+
+1. 1× primary IP per VM
+2. 1× secondary private IP per configured StaticGatewayConfiguration
+3. Azure reserved addresses (first 4 IPs in the subnet: network, gateway, DNS × 2)
+4. Additional headroom for surge during rolling upgrades
+
+The Azure Resource Provider validates subnet capacity when you create or update VM gateway pools.
+
+**Use cases:**
+* Accessing Azure Private Link services (e.g., Storage, Key Vault, SQL Database)
+* Connecting to on-premises resources via ExpressRoute or VPN Gateway
+* Communicating with private endpoints in peered VNets
+* Scenarios where Internet connectivity is not required
+* Compliance requirements to avoid public IP exposure or when public IP resources are not needed
+
+**Configuration:**
+```yaml
+spec:
+  # VM-based gateway nodepool required for private IP only mode
+  gatewayNodepoolName: myGatewayNodepool
+  
+  # Set to false to skip public IP provisioning
+  provisionPublicIps: false
+```
+
+**Provisioning process:**
+
+When you create or update a StaticGatewayConfiguration with `provisionPublicIps: false`, the controller:
+
+1. Checks/creates the internal load balancer (ILB) and backend pool
+2. Ensures each selected gateway node has the secondary private IP in its NIC `ipConfigurations[]`
+3. Updates the StaticGatewayConfiguration status with assigned private IP addresses
+
+**Verifying IP assignment:**
+
+After deployment, verify the assigned private IPs in the StaticGatewayConfiguration status:
+
+```bash
+kubectl get staticgatewayconfigurations -n <namespace> <name> -o jsonpath='{.status.egressIpPrefix}'
+```
+
+The `egressIpPrefix` field will show a comma-separated list of private IPs (e.g., `10.0.1.8,10.0.1.9`). These IPs remain stable across node operations.
+
+**Important considerations:**
+* When using `gatewayNodepoolName` (VM-based gateway nodepools), you have the flexibility to set `provisionPublicIps` to false
+* Ensure your network configuration (ExpressRoute, VPN, Private Link, VNet peering) is properly set up to route traffic to the intended private destinations
+* No public IP prefix resources will be created
+* The `publicIpPrefixId` field cannot be used when `provisionPublicIps` is false 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,27 @@ status:
     Port: 6000
   egressIpPrefix: 1.2.3.4/31 # egress public IP prefix
 ```
-The controller creates a secret storing the gateway side wireguard private key with the same namespace and name as your `StaticGatewayConfiguration`. This information is displayed in `.status.gatewayServerProfile.PrivateKeySecretRef` field. `PublicKey` is base64 encoded wireguard public key used by the gateway. `Ip` is the gateway ILB frontend IP. This IP comes from the subnet provided in Azure cloud config. `Port` is LoadBalancing rule frontend and backend port. All `StaticGatewayConfiguration`s deployed to the same gateway VMSS share the same ILB frontend and backend but have separate LoadBalancing rules with different ports. And most importantly, `egressIpPrefix` is the egress source IPNet of the pods using this gateway. If you see any of these not showing in status, you can describe the CR objects and see if there are error events:
+
+The controller creates a secret storing the gateway side wireguard private key with the same namespace and name as your `StaticGatewayConfiguration`. This information is displayed in `.status.gatewayServerProfile.PrivateKeySecretRef` field. `PublicKey` is base64 encoded wireguard public key used by the gateway. `Ip` is the gateway ILB frontend IP. This IP comes from the subnet provided in Azure cloud config. `Port` is LoadBalancing rule frontend and backend port. All `StaticGatewayConfiguration`s deployed to the same gateway nodepool share the same ILB frontend and backend but have separate LoadBalancing rules with different ports.
+
+**Understanding `egressIpPrefix`:**
+
+The `egressIpPrefix` field shows the egress source IP(s) that pods using this gateway will use:
+
+* **For public IP mode** (`provisionPublicIps: true`): Shows the public IP prefix in CIDR notation (e.g., `1.2.3.4/31`)
+* **For private IP only mode** (`provisionPublicIps: false`, VM gateway pools only): Shows a comma-separated list of private IPs assigned to the gateway nodes (e.g., `10.0.1.8,10.0.1.9`)
+
+For private IP mode, these IPs are secondary private IPs pinned to the pre-created NICs of the gateway VMs and remain stable across node restarts and upgrades.
+
+**Verifying IP assignment:**
+
+You can quickly check the assigned egress IPs using:
+
+```bash
+kubectl get staticgatewayconfigurations -n <your namespace> <your sgw name> -o jsonpath='{.status.egressIpPrefix}'
+```
+
+If you see any of these status fields not populated, you can describe the CR objects to see if there are error events:
 ```bash
 $ kubectl describe staticcgatewayconfiguration -n <your namespace> <your sgw name>
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Updates documentation to reflect the newly merged private IP support for static egress gateways. This PR adds comprehensive guidance for customers on:

- How to enable private IP only mode for accessing private endpoints 
- Technical requirements: VM-based gateway nodepools (`gatewayNodepoolName`) and Kubernetes ≥ 1.34
- Why VM gateway pools are required instead of VMSS (pre-created NICs, stable IP assignment, deterministic secondary IPs across scale/upgrade operations)
- Subnet sizing requirements (primary IPs, secondary IPs, Azure reserved addresses, upgrade headroom)
- How the controller provisions private IPs (ILB creation, NIC ipConfigurations, status updates)
- How to verify IP assignment via StaticGatewayConfiguration status fields

#### Which issue(s) this PR fixes:

Fixes #


#### Special notes for your reviewer
