### PR TITLE
fix stale entry cleanup and add retry logic with exponential backoff

### DIFF
--- a/controllers/daemon/podendpoint_controller_test.go
+++ b/controllers/daemon/podendpoint_controller_test.go
@@ -297,7 +297,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 
 		It("should create new gateway status object if not exist", func() {
 			getTestReconciler(node)
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, true)
 			Expect(err).To(BeNil())
 			gwStatus := &egressgatewayv1alpha1.GatewayStatus{}
 			err = getGatewayStatus(r.Client, gwStatus)
@@ -329,7 +329,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 			allPeers := append(peerConfigs,
 				egressgatewayv1alpha1.PeerConfiguration{PublicKey: "pubk1", InterfaceName: "wg-6000"},
 				egressgatewayv1alpha1.PeerConfiguration{PublicKey: "pubk3", InterfaceName: "wg-6002"})
-			err := r.updateGatewayNodeStatus(context.TODO(), allPeers)
+			err := r.updateGatewayNodeStatus(context.TODO(), allPeers, false)
 			Expect(err).To(BeNil())
 			gwStatus := &egressgatewayv1alpha1.GatewayStatus{}
 			err = getGatewayStatus(r.Client, gwStatus)
@@ -366,7 +366,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 			peersToKeep := []egressgatewayv1alpha1.PeerConfiguration{
 				{PublicKey: "pubk3", InterfaceName: "ns3"},
 			}
-			err := r.updateGatewayNodeStatus(context.TODO(), peersToKeep)
+			err := r.updateGatewayNodeStatus(context.TODO(), peersToKeep, false)
 			Expect(err).To(BeNil())
 			gwStatus := &egressgatewayv1alpha1.GatewayStatus{}
 			err = getGatewayStatus(r.Client, gwStatus)
@@ -674,7 +674,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 			}
 			
 			// The retry logic should handle this gracefully
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, false)
 			Expect(err).To(BeNil())
 			
 			// Verify the peer was added
@@ -695,7 +695,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 				},
 			}
 			
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, true)
 			Expect(err).To(BeNil())
 			
 			gwStatus := &egressgatewayv1alpha1.GatewayStatus{}
@@ -731,7 +731,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 				},
 			}
 			
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, false)
 			Expect(err).To(BeNil())
 			
 			// Verify no update was made (ResourceVersion should not change)
@@ -768,7 +768,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 				},
 			}
 			
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, false)
 			Expect(err).To(BeNil())
 			
 			// Original peer should still be there
@@ -785,7 +785,7 @@ var _ = Describe("Daemon PodEndpoint controller unit tests", func() {
 			// Pass empty peersToKeep - should not create GatewayStatus
 			peerConfigs := []egressgatewayv1alpha1.PeerConfiguration{}
 			
-			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs)
+			err := r.updateGatewayNodeStatus(context.TODO(), peerConfigs, false)
 			Expect(err).To(BeNil())
 			
 			// GatewayStatus should not be created


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
This PR fixes two critical bugs in the PodEndpoint controller that caused GatewayStatus CRs to exceed etcd's 1.5 MB size limit in high-churn environments:

**Bug 1: Stale peer entries never cleaned from GatewayStatus**
- The cleanup logic only removed peers that existed in the wireguard device but not in PodEndpoint CRs
- Peers that were already removed from the device (e.g., during crashes, manual cleanup, or pod deletions) were orphaned forever in GatewayStatus
- Eventually exceeded etcd's 1.5 MB limit, causing errors: `failed to update gwStatus object: etcdserver: request is too large`

**Bug 2: Concurrent update conflicts**
- No retry logic for GatewayStatus updates caused frequent conflicts during simultaneous reconciliation
- Resulted in repeated errors: `failed to update gwStatus object: Operation cannot be fulfilled on gatewaystatuses.egressgateway.kubernetes.azure.com: the object has been modified; please apply your changes to the latest version and try again`

Fixes #
Builds `peersToKeep` list containing only peers that:
- Exist in the wireguard device AND
- Have corresponding PodEndpoint CRs
Peers missing from wireguard device (stale/orphaned) are implicitly excluded from `peersToKeep`

Added retry logic in `updateGatewayNodeStatus()`:
   - Implements retry loop with up to 5 attempts for handling concurrent modifications
   - Properly detects and handles `IsConflict` errors with fresh object fetches
   - Handles `AlreadyExists` race condition during GatewayStatus creation
   - Early exit optimization when no changes are needed (reduces etcd load)
   - Improved structured logging for better observability

#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->