### PR TITLE
fix: `--set` should use strings not int

### DIFF
--- a/.pipeline/scripts/deploy-testenv.sh
+++ b/.pipeline/scripts/deploy-testenv.sh
@@ -68,7 +68,7 @@ echo "Performing post-deployment configurations"
 
 # this has to be done manually because aks-managed tags are not allowed through aks-rp
 VMSS=$(az vmss list -g ${NODE_RESOURCE_GROUP} | jq --arg GW_NODE_POOL_NAME "${GW_NODE_POOL_NAME}" -r '.[] | select(.tags["aks-managed-poolName"] == $GW_NODE_POOL_NAME) | .name')
-az vmss update --name ${VMSS} -g ${NODE_RESOURCE_GROUP} --set tags.aks-managed-gatewayIPPrefixSize=31 > /dev/null
+az vmss update --name ${VMSS} -g ${NODE_RESOURCE_GROUP} --set tags.'aks-managed-gatewayIPPrefixSize'='"31"' > /dev/null
 
 # Generate azure configuration file for the controllers
 echo "Generating azure configuration file: $(pwd)/azure.json"


### PR DESCRIPTION
Currently causing this error:

```
ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: Expect <class 'str'>, got 31 (<class 'int'>)
Traceback (most recent call last):
  File "/opt/az/lib/python3.13/site-packages/azure/cli/core/aaz/_field_type.py", line 49, in process_data
    json_data = shell_safe_json_parse(data)
  File "/opt/az/lib/python3.13/site-packages/azure/cli/core/util.py", line 575, in shell_safe_json_parse
    return json.loads(json_or_dict_string, strict=strict)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/az/lib/python3.13/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
                    f'not {s.__class__.__name__}')
TypeError: the JSON object must be str, bytes or bytearray, not int
```

<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->