### PR TITLE
Update Go version to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/Azure/kube-egress-gateway
 
 go 1.26.3
-toolchain 1.26.3
+toolchain go1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Azure/kube-egress-gateway
 
-go 1.26.2
+go 1.26.3
+toolchain 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Bump go toolchain to 1.26.3 to address CVEs, for Azure builds.