### PR TITLE
Add 169.254.169.254/32 (Azure IMDS) and 169.254.10.11/32 (AKS node-local DNS) to the default gatewayCNIManager.exceptionCidrs

### DIFF
--- a/helm/kube-egress-gateway/README.md
+++ b/helm/kube-egress-gateway/README.md
@@ -112,7 +112,7 @@ Additionally, `common.gatewayLbProbePort` defines the gateway LoadBalancer probe
 | `gatewayCNIManager.imageTag` | | Tag of gatewayCNIManager image. |
 | `gatewayCNIManager.imagePullPolicy` | `IfNotPresent` | Image pull policy for gatewayCNIManager's image. |
 | `gatewayCNIManager.grpcServerPort` | `50051` | Port which cniManager grpc server listens on. Also used for cniManager pod liveness and readiness probes. |
-| `gatewayCNIManager.exceptionCidrs` | `[""]` | A list of cidrs that should be exempted from all egress gateways, e.g. intra-cluster traffic. |
+| `gatewayCNIManager.exceptionCidrs` | `["169.254.169.254/32", "169.254.10.11/32"]` | A list of cidrs that should be exempted from all egress gateways, e.g. intra-cluster traffic. Defaults to Azure IMDS and AKS node-local DNS, which are node-local endpoints that must not traverse the gateway VMSS. |
 | `gatewayCNIManager.cniConfigFileName` | `01-egressgateway.conflist` | Name of the newly generated cni configuration list file. |
 | `gatewayCNIManager.cniUninstallConfigMapName` | `cni-uninstall` | Name of the configMap indicating whether cni plugin needs to be uninstalled upon gatewayCNIManager pod shutdown. |
 | `gatewayCNIManager.cniUninstall` | `false` | Boolean indicating whether to uninstall kube-egress-gateway CNI plugin upon gatewayCNIManager pod shutdown. |

--- a/helm/kube-egress-gateway/values.yaml
+++ b/helm/kube-egress-gateway/values.yaml
@@ -23,8 +23,13 @@ gatewayCNIManager:
   # imageTag: ""
   imagePullPolicy: "IfNotPresent"
   grpcServerPort: 50051
+  # Cidrs that should bypass the egress gateway, e.g. intra-cluster traffic.
+  # The two link-local entries below (Azure IMDS and AKS node-local DNS) are
+  # node-local and must not be routed through the gateway VMSS; keep them
+  # unless you have a specific reason to remove them.
   exceptionCidrs:
-    - ""
+    - "169.254.169.254/32"
+    - "169.254.10.11/32"
   cniConfigFileName: "01-egressgateway.conflist"
   cniUninstallConfigMapName: "cni-uninstall"
   cniUninstall: false


### PR DESCRIPTION
Adds `169.254.169.254/32` (Azure IMDS) and `169.254.10.11/32` (AKS node-local DNS) to the default `gatewayCNIManager.exceptionCidrs` list shipped by the Helm chart, so they bypass the egress gateway out of the box.

| CIDR | Purpose |
| --- | --- |
| `169.254.169.254/32` | Azure Instance Metadata Service (IMDS) |
| `169.254.10.11/32`   | AKS node-local DNS |

## Why

Both endpoints are **node-local** link-local addresses. Routing them through the gateway VMSS breaks them in non-obvious ways:

- **IMDS** is used by `pkg/imds`, Managed Service Identity (MSI) token acquisition, the Azure cloud-provider, and most Azure SDKs. Sending it through the tunnel breaks instance metadata lookups and MSI auth.
- **AKS node-local DNS** is the node-side cache used for in-cluster DNS resolution. Tunneling it breaks DNS for every pod on the node.

Until now chart users had to remember to add both CIDRs to `gatewayCNIManager.exceptionCidrs` themselves. Forgetting either one only produced visible failures after pod traffic started flowing, which made the failure mode hard to diagnose. Shipping these as defaults eliminates the footgun.

## How

Pure Helm chart change — no binary changes, no new flags, no merging logic. The cnimanager's existing `--exception-cidrs` argument is unchanged; the chart simply renders a different default list into it.

- [`helm/kube-egress-gateway/values.yaml`](helm/kube-egress-gateway/values.yaml): replaces the empty `exceptionCidrs: [""]` placeholder with the two CIDRs above, and adds a comment explaining why.
- [`helm/kube-egress-gateway/README.md`](helm/kube-egress-gateway/README.md): updated default and description.