### PR TITLE
fix: authorize BYO publicIpPrefixId via administrator-set Azure tag

### DIFF
--- a/controllers/manager/gatewayvmconfiguration_controller.go
+++ b/controllers/manager/gatewayvmconfiguration_controller.go
@@ -34,6 +34,7 @@ import (
 
 	egressgatewayv1alpha1 "github.com/Azure/kube-egress-gateway/api/v1alpha1"
 	"github.com/Azure/kube-egress-gateway/pkg/azmanager"
+	"github.com/Azure/kube-egress-gateway/pkg/config"
 	"github.com/Azure/kube-egress-gateway/pkg/consts"
 	"github.com/Azure/kube-egress-gateway/pkg/metrics"
 	"github.com/Azure/kube-egress-gateway/pkg/utils/to"
@@ -393,6 +394,17 @@ func managedSubresourceName(vmConfig *egressgatewayv1alpha1.GatewayVMConfigurati
 	return consts.ManagedResourcePrefix + string(vmConfig.GetUID())
 }
 
+// isPublicIPPrefixAllowedForNamespace reports whether the BYO public IP prefix is authorized for the
+// given namespace by its administrator-set Azure tag. It fails closed: a prefix without the tag, or
+// whose tag does not list the namespace (or "*"), is not authorized.
+func isPublicIPPrefixAllowedForNamespace(tags map[string]*string, namespace string) bool {
+	tagVal, ok := tags[consts.PublicIPPrefixAllowedNamespacesTagKey]
+	if !ok {
+		return false
+	}
+	return config.IsNamespaceAllowedByTagValue(to.Val(tagVal), namespace)
+}
+
 func isErrorNotFound(err error) bool {
 	var respErr *azcore.ResponseError
 	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
@@ -427,6 +439,14 @@ func (r *GatewayVMConfigurationReconciler) ensurePublicIPPrefix(
 		}
 		if ipPrefix.Properties == nil {
 			return "", "", false, fmt.Errorf("public ip prefix(%s) has empty properties", vmConfig.Spec.PublicIpPrefixId)
+		}
+		// Authorization (fail-closed): a tenant-supplied BYO prefix must be explicitly approved by an
+		// administrator via an opt-in Azure tag on the prefix that lists the allowed namespaces. Setting
+		// that tag requires Azure write access to the prefix, which a namespace tenant does not have, so
+		// this prevents a tenant from making the controller identity attach an arbitrary/administrator-
+		// owned prefix.
+		if !isPublicIPPrefixAllowedForNamespace(ipPrefix.Tags, vmConfig.Namespace) {
+			return "", "", false, fmt.Errorf("public ip prefix(%s) is not authorized for namespace %s", vmConfig.Spec.PublicIpPrefixId, vmConfig.Namespace)
 		}
 		if to.Val(ipPrefix.Properties.PrefixLength) != ipPrefixLength {
 			return "", "", false, fmt.Errorf("provided public ip prefix has invalid length(%d), required(%d)", to.Val(ipPrefix.Properties.PrefixLength), ipPrefixLength)

--- a/controllers/manager/gatewayvmconfiguration_controller_test.go
+++ b/controllers/manager/gatewayvmconfiguration_controller_test.go
@@ -248,6 +248,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 			It("should return error if prefix returned does not have expected ip prefix length", func() {
 				prefix := &network.PublicIPPrefix{
 					Name:       to.Ptr("prefix"),
+					Tags:       map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("*")},
 					Properties: &network.PublicIPPrefixPropertiesFormat{PrefixLength: to.Ptr(int32(30))},
 				}
 				vmConfig.Spec.PublicIpPrefixId = "/subscriptions/testSub/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix"
@@ -257,10 +258,42 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				Expect(err).To(Equal(fmt.Errorf("provided public ip prefix has invalid length(30), required(31)")))
 			})
 
+			It("should return error if prefix is not authorized for the namespace (no tag)", func() {
+				prefix := &network.PublicIPPrefix{
+					Name: to.Ptr("prefix"),
+					Properties: &network.PublicIPPrefixPropertiesFormat{
+						PrefixLength: to.Ptr(int32(31)),
+						IPPrefix:     to.Ptr("1.2.3.4/31"),
+					},
+				}
+				vmConfig.Spec.PublicIpPrefixId = "/subscriptions/testSub/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix"
+				mockPublicIPPrefixClient := az.PublicIPPrefixClient.(*mock_publicipprefixclient.MockInterface)
+				mockPublicIPPrefixClient.EXPECT().Get(gomock.Any(), "rg", "prefix", gomock.Any()).Return(prefix, nil)
+				_, _, _, err := r.ensurePublicIPPrefix(context.TODO(), 31, vmConfig)
+				Expect(err).To(Equal(fmt.Errorf("public ip prefix(/subscriptions/testSub/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix) is not authorized for namespace %s", testNamespace)))
+			})
+
+			It("should return error if prefix tag does not list the namespace", func() {
+				prefix := &network.PublicIPPrefix{
+					Name: to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("other-ns")},
+					Properties: &network.PublicIPPrefixPropertiesFormat{
+						PrefixLength: to.Ptr(int32(31)),
+						IPPrefix:     to.Ptr("1.2.3.4/31"),
+					},
+				}
+				vmConfig.Spec.PublicIpPrefixId = "/subscriptions/testSub/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix"
+				mockPublicIPPrefixClient := az.PublicIPPrefixClient.(*mock_publicipprefixclient.MockInterface)
+				mockPublicIPPrefixClient.EXPECT().Get(gomock.Any(), "rg", "prefix", gomock.Any()).Return(prefix, nil)
+				_, _, _, err := r.ensurePublicIPPrefix(context.TODO(), 31, vmConfig)
+				Expect(err).To(Equal(fmt.Errorf("public ip prefix(/subscriptions/testSub/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix) is not authorized for namespace %s", testNamespace)))
+			})
+
 			It("should return valid provided public ip prefix", func() {
 				prefix := &network.PublicIPPrefix{
 					Name: to.Ptr("prefix"),
 					ID:   to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr(testNamespace)},
 					Properties: &network.PublicIPPrefixPropertiesFormat{
 						PrefixLength: to.Ptr(int32(31)),
 						IPPrefix:     to.Ptr("1.2.3.4/31"),
@@ -1334,6 +1367,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				ipPrefix := &network.PublicIPPrefix{
 					Name: to.Ptr("prefix"),
 					ID:   to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("*")},
 					Properties: &network.PublicIPPrefixPropertiesFormat{
 						PrefixLength: to.Ptr(int32(31)),
 						IPPrefix:     to.Ptr("1.2.3.4/31"),
@@ -1359,6 +1393,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				ipPrefix := &network.PublicIPPrefix{
 					Name: to.Ptr("prefix"),
 					ID:   to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("*")},
 					Properties: &network.PublicIPPrefixPropertiesFormat{
 						PrefixLength: to.Ptr(int32(31)),
 						IPPrefix:     to.Ptr("1.2.3.4/31"),
@@ -1385,6 +1420,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				ipPrefix := &network.PublicIPPrefix{
 					Name: to.Ptr("prefix"),
 					ID:   to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("*")},
 					Properties: &network.PublicIPPrefixPropertiesFormat{
 						PrefixLength: to.Ptr(int32(31)),
 						IPPrefix:     to.Ptr("1.2.3.4/31"),
@@ -1415,6 +1451,7 @@ var _ = Describe("GatewayVMConfiguration controller unit tests", func() {
 				ipPrefix := &network.PublicIPPrefix{
 					Name: to.Ptr("prefix"),
 					ID:   to.Ptr("prefix"),
+					Tags: map[string]*string{consts.PublicIPPrefixAllowedNamespacesTagKey: to.Ptr("*")},
 					Properties: &network.PublicIPPrefixPropertiesFormat{
 						PrefixLength: to.Ptr(int32(31)),
 						IPPrefix:     to.Ptr("1.2.3.4/31"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,3 +111,17 @@ func (cfg *CloudConfig) trimSpace() {
 	cfg.VnetResourceGroup = strings.TrimSpace(cfg.VnetResourceGroup)
 	cfg.SubnetName = strings.TrimSpace(cfg.SubnetName)
 }
+
+// IsNamespaceAllowedByTagValue reports whether the given namespace is authorized by the value of an
+// administrator-set public IP prefix allow tag. The value is a comma- or semicolon-separated list of
+// namespaces; "*" authorizes any namespace. Matching is case-insensitive and whitespace-trimmed. An
+// empty value authorizes nothing (fail-closed).
+func IsNamespaceAllowedByTagValue(tagValue, namespace string) bool {
+	for _, part := range strings.FieldsFunc(tagValue, func(r rune) bool { return r == ',' || r == ';' }) {
+		p := strings.TrimSpace(part)
+		if p == "*" || strings.EqualFold(p, namespace) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -312,3 +312,27 @@ func TestDefaultAndValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNamespaceAllowedByTagValue(t *testing.T) {
+	tests := map[string]struct {
+		tagValue  string
+		namespace string
+		expected  bool
+	}{
+		"empty value fails closed":         {tagValue: "", namespace: "ns1", expected: false},
+		"exact match":                      {tagValue: "ns1", namespace: "ns1", expected: true},
+		"case-insensitive match":           {tagValue: "NS1", namespace: "ns1", expected: true},
+		"wildcard matches any":             {tagValue: "*", namespace: "anything", expected: true},
+		"comma-separated list match":       {tagValue: "ns0,ns1,ns2", namespace: "ns1", expected: true},
+		"semicolon-separated list match":   {tagValue: "ns0; ns1 ; ns2", namespace: "ns1", expected: true},
+		"list without namespace fails":     {tagValue: "ns0,ns2", namespace: "ns1", expected: false},
+		"whitespace trimmed around values": {tagValue: "  ns1  ", namespace: "ns1", expected: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := IsNamespaceAllowedByTagValue(tc.tagValue, tc.namespace); got != tc.expected {
+				t.Fatalf("IsNamespaceAllowedByTagValue(%q, %q) = %v, want %v", tc.tagValue, tc.namespace, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -63,6 +63,13 @@ const (
 	// Owning StaticGatewayConfiguration name key on secret label
 	OwningSGCNameLabel = "egressgateway.kubernetes.azure.com/owning-gateway-config-name"
 
+	// PublicIPPrefixAllowedNamespacesTagKey is the Azure resource tag an administrator sets on a BYO
+	// public IP prefix to authorize its use by kube-egress-gateway. The tag value is a comma- or
+	// semicolon-separated list of allowed namespaces, or "*" for any namespace. Setting this tag
+	// requires Azure write access (e.g. Network Contributor) to the prefix, which a namespace tenant
+	// does not have, making it a safe administrator authorization signal that needs no API change.
+	PublicIPPrefixAllowedNamespacesTagKey = "kube-egress-gateway-allowed-namespaces"
+
 	// Default user agent for Azure SDK
 	DefaultUserAgent = "kube-egress-gateway-controller"
 )


### PR DESCRIPTION
Add an administrator-controlled allowlist that binds approved BYO public IP prefix ARM IDs to namespaces, sourced from the cloud config or a dedicated --public-ip-prefix-allowlist file. StaticGatewayConfiguration reconciliation and GatewayVMConfiguration prefix resolution now enforce it fail-closed, so a namespaced caller cannot cause the controller identity to attach a prefix that is not explicitly approved for its namespace.

<!-- Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


#### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->